### PR TITLE
Robustly retrieve user field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ test/
 *egg-info
 *.ipy*
 *figures
+
+env*/

--- a/slitlessutils/core/modules/extract/multi/multi.py
+++ b/slitlessutils/core/modules/extract/multi/multi.py
@@ -3,8 +3,7 @@ from astropy.io import fits
 from matplotlib.backends.backend_pdf import PdfPages
 import numpy as np
 
-import os
-import pwd
+import getpass
 
 
 from .....config import Config,SUFFIXES
@@ -143,7 +142,7 @@ class Multi(Module):
             # add some info to the PDF
             d=pdf.infodict()
             d['Title']='L-Curve Results'
-            d['Author']=pwd.getpwuid(os.getuid()).pw_gecos
+            d['Author']=getpass.getuser()
             d['Subject']=f'L-Curve results for grouped data from {__code__}'
             d['Keywords']=f'{__code__} WFSS L-curve groups'
             d['Producer']=__code__


### PR DESCRIPTION
In a subroutine that writes out a PDF, the author field is filled with the current user's username. This presents a robustness problem, as this relies on the user to have filled in the user NAME field when setting up their account (i.e. `John Smith` instead of `jsmith`). I do believe this field is optional when setting up an account.

Instead, this PR replaces the `pwd.getpwuid` call with the python suggested `getpass.getuser` call and writes out `jsmith`, which is guaranteed.

As a side effect, this was the only additional change on top of #2 to get slitlessutils to install and import successfully on Windows 🎉 