### PR TITLE
remove unsupported `system_packages` RTD config setting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,6 @@ sphinx:
   fail_on_warning: true
 
 python:
-  system_packages: false
   install:
     - method: pip
       path: .


### PR DESCRIPTION
RTD no longer supports any `system_packages` setting: https://blog.readthedocs.com/drop-support-system-packages/

This PR removes the unused `system_packages` setting