### PR TITLE
updating interface and print for wfsscollection.py

### DIFF
--- a/slitlessutils/core/wfss/data/wfsscollection.py
+++ b/slitlessutils/core/wfss/data/wfsscollection.py
@@ -336,9 +336,7 @@ class WFSSCollection(dict):
             cols['blocking'].append(data.disperser.blocking)
 
         # repackage as a Table object
-        tab = Table(cols)
-
-        return tab
+        return Table(cols)
 
     def from_index(self, i):
         """

--- a/slitlessutils/core/wfss/data/wfsscollection.py
+++ b/slitlessutils/core/wfss/data/wfsscollection.py
@@ -444,7 +444,7 @@ class WFSSCollection(dict):
         return obj
 
     @classmethod
-    def from_list(cls, filenames, filename='<list>'):
+    def from_list(cls, filenames, filename='<LIST>'):
         """
         Classmethod to load a `WFSSCollection` from a list
 


### PR DESCRIPTION
This PR makes a few minor modifications to wfsscollection and instrumentconfig.

1. improves the __str__ function so `print` gives a more useful message.  It does this by adding a new method `as_table` to distill the contents to an `astropy.table.Table` object, and leverage the ``__str__`` method of that class.  Future improvements could add more info to this table method, but this seemed good enough for now.
2. update the `from_wcsfile` class method to replace all spaces in the CSV files.
3. change the classmethods ``from_glob`` and ``from_file`` to use the class method ``from_list``, which was modified to do the checking for the obstype.
4. add checking in instrumentconfig for a few things and give useful error messages
   - check for invalid disperser/blocking combinations
   - check for invalid obstype (must be "SPECTROSCOPIC")
  
The items 3/4 catch some corner cases that @haticekaratay found. 

Also.  there are no changes to the RtD page(s) for this code change. 