### PR TITLE
Put codestyle check back in after accidental removal

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -30,11 +30,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Code style checks
-            os: ubuntu-latest
+          - os: ubuntu-latest
             python: 3.x
             toxenv: codestyle
             allow_failure: false
+            prefix: 'Codestyle Checks'
 
           - os: ubuntu-latest
             python: '3.9'

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -30,6 +30,12 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: Code style checks
+            os: ubuntu-latest
+            python: 3.x
+            toxenv: codestyle
+            allow_failure: false
+
           - os: ubuntu-latest
             python: '3.9'
             tox_env: 'py39-test'


### PR DESCRIPTION
@larrybradley it looks like your package infrastructure PR left out the codestyle check when you moved things to `ci_tests.yml`. I assume this was accidental, but if it was on purpose let me know.