### PR TITLE
Use new pypolyclip function name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     'matplotlib>=3.5.2',
     'pandas>=1.4.2',
     'psutil>=5.9.0',
-    'pypolyclip',
+    'pypolyclip>=1.0.0',
     'pysiaf>=0.16.4',
     'scikit-image>=0.19.2',
     'scipy>=1.8.0',

--- a/slitlessutils/core/wfss/config/instrumentconfig.py
+++ b/slitlessutils/core/wfss/config/instrumentconfig.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from astropy.io import fits
 import numpy as np
-import pypolyclip
+from pypolyclip import clip_multi
 import pysiaf
 import yaml
 
@@ -559,7 +559,7 @@ class DetectorConfig:
         yg = np.clip(yg, 0, self.naxis[1])
 
         # clip against the pixel grid
-        x, y, area, slices = pypolyclip.multi(xg, yg, self.naxis)
+        x, y, area, slices = clip_multi(xg, yg, self.naxis)
 
         # make wavelength indices
         lam = np.empty_like(x, dtype=np.uint16)


### PR DESCRIPTION
This should not be merged until a new `pypolyclip` is released on PyPI.
https://pypi.org/project/pypolyclip/#history

Tests are not going to pass because the tox test env will be installing the 0.1a version of `pypolyclip`.