### PR TITLE
Update install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ Slitlessutils is under active development software and subject to change.
 
 ## Quickstart
 
-To install the latest version of this repository, please use:
-``
+The latest released version of this package can be installed using pip
+from the command line:
+```
+pip install slitlessutils
+```
+
+To install the latest develoment version of this repository, please use:
+```
 pip install git+https://github.com/spacetelescope/slitlessutils.git
-``
+```
 
 You also need to obtain the calibration (reference) files, which are stored in a public box folder, which can be done with the slitlessutils config objects.  Please see [configuring slitlessutils](https://slitlessutils.readthedocs.io/en/latest/configure.html)
 for instructions and examples.  Please see our [documentation](https://slitlessutils.readthedocs.io/en/latest/install.html)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To install the latest version of this repository, please use:
 pip install git+https://github.com/spacetelescope/slitlessutils.git
 ``
 
-You also need to obtain the calibration (reference) files, which are stored in a public box folder, which can be done with the slitlessutils config objects.  Please see [configuring slitlessutils](https://github.com/spacetelescope/slitlessutils/blob/main/docs/configure.rst) for instructions and examples.  Please see [our documentation](https://github.com/spacetelescope/slitlessutils/blob/main/docs/install.rst) for additional installation instructions and/or methods.
+You also need to obtain the calibration (reference) files, which are stored in a public box folder, which can be done with the slitlessutils config objects.  Please see [configuring slitlessutils](https://slitlessutils.readthedocs.io/en/latest/configure.html)
+for instructions and examples.  Please see our [documentation](https://slitlessutils.readthedocs.io/en/latest/install.html)
+for additional installation instructions and/or methods.
 
-We have encountered several frequently-asked questions and give some examples [our FAQ page](https://github.com/spacetelescope/slitlessutils/blob/main/docs/faq.rst).
+We have encountered several frequently-asked questions and give some examples our [FAQ page](https://slitlessutils.readthedocs.io/en/latest/faq.html).

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,6 +25,12 @@ Installing ``slitlessutils``
 
 There are several ways to install ``slitlessutils``:
 
+* **Install from PyPI:** to install the latest stable version:
+
+  .. code-block:: bash
+
+    pip install slitlessutils
+
 
 * **Install from GitHub:** to install the latest development version:
 


### PR DESCRIPTION
Adds `pip install slitlessutils` for the latest stable (released) version.

Also updates the readme to link to RTD pages instead of raw `rst` files.