### PR TITLE
bug fixes for rotation and FWCPOS, orbit/subarray seettings and all v…

### DIFF
--- a/slitlessutils/core/modules/extract/single/single.py
+++ b/slitlessutils/core/modules/extract/single/single.py
@@ -446,7 +446,7 @@ class Single(Module):
 
         # sort out optional inputs
         cartesian = kwargs.get('cartesian', True)
-        profile = kwargs.get('profile', 'data').lower()
+        profile = kwargs.get('profile', 'uniform').lower()
 
         # padding for the contamination models
         padx = (5, 5)

--- a/slitlessutils/core/modules/region/region.py
+++ b/slitlessutils/core/modules/region/region.py
@@ -94,30 +94,28 @@ class Region(Module):
             ltv2 = hdr.get('LTV2', 0.)
             nx = hdr['NAXIS1']
             ny = hdr['NAXIS2']
-            
+
             regfile = f'{data.dataset}_{detdata.name}.reg'
             outfiles.append(regfile)
             with ds9reg.DS9Regions(regfile, **kwargs) as rf:
 
                 for segid, source in sources.items():
-                    
-
                     x, y = [], []
                     for pixels in source.pixels():
                         x.append(pixels[0])
                         y.append(pixels[1])
                     x = np.asarray(x)
                     y = np.asarray(y)
-                    
+
                     xx, yy = detdata.xy2xy(x, y, source.wcs, forward=False)
-                    
+
                     for order in orders:
                         xg, yg = detdata.config.config.disperse(xx, yy, order, wav)
                         xg = xg.flatten()
                         yg = yg.flatten()
-                        #if any(xg>0) or any(xg<nx-1) or any(yg>0) or any(yg<ny-1):
-                        if any((0<xg) & (xg<nx-1) & (0<yg) & (yg<ny-1)):
-                            
+                        # if any(xg>0) or any(xg<nx-1) or any(yg>0) or any(yg<ny-1):
+                        if any((0 < xg) & (xg < nx - 1) & (0 < yg) & (yg < ny - 1)):
+
                             xg = xg.astype(int).flatten()
                             yg = yg.astype(int).flatten()
 
@@ -139,13 +137,9 @@ class Region(Module):
                             msk[yg - y0 + 1, xg - x0 + 1] = 1
                             msk = ndimage.binary_closing(msk, structure=struct)
 
-
-                          
-                            
                             # get the contour
                             contours = measure.find_contours(msk.astype(int), 0.1,
                                                              fully_connected='high')
-
 
                             # get the color for the order
                             color = self.COLORS.get(order, 'green')
@@ -154,10 +148,10 @@ class Region(Module):
                             for contour in contours:
                                 xc = contour[::self.nthin, 1] + x0 - ltv1
                                 yc = contour[::self.nthin, 0] + y0 - ltv2
-                                
+
                                 # create the region
                                 reg = ds9reg.Polygon(xc, yc, color=color)
-                                
+
                                 # write to the file
                                 rf.write_region(reg)
 

--- a/slitlessutils/core/wfss/config/wfssconfig.py
+++ b/slitlessutils/core/wfss/config/wfssconfig.py
@@ -42,7 +42,7 @@ class WFSSConfig(dict):
         self.ffname = None
         self.set_rotation(0.)
         self.set_shift(0., 0.)
-        
+
         # read the data
         self.data = self.read_asciifile(self.conffile)
 
@@ -89,7 +89,7 @@ class WFSSConfig(dict):
         None
         """
         self.set_rotation(fwcpos - self.data['FWCPOS_REF'][0])
-                
+
     def set_rotation(self, theta):
         """
         Method to set a rotation in the spectral trace.
@@ -106,7 +106,7 @@ class WFSSConfig(dict):
         self.theta = theta
         self.cos = np.cos(np.radians(self.theta))
         self.sin = np.sin(np.radians(self.theta))
-        
+
     def add_rotation(self, dtheta):
         """
         Method to update the current spectral dispersion  rotation angle

--- a/slitlessutils/core/wfss/config/wfssconfig.py
+++ b/slitlessutils/core/wfss/config/wfssconfig.py
@@ -42,7 +42,7 @@ class WFSSConfig(dict):
         self.ffname = None
         self.set_rotation(0.)
         self.set_shift(0., 0.)
-
+        
         # read the data
         self.data = self.read_asciifile(self.conffile)
 
@@ -88,8 +88,8 @@ class WFSSConfig(dict):
         -------
         None
         """
-        self.set_rotation(fwcpos - self.data['FWCPOS_REF'])
-
+        self.set_rotation(fwcpos - self.data['FWCPOS_REF'][0])
+                
     def set_rotation(self, theta):
         """
         Method to set a rotation in the spectral trace.
@@ -103,10 +103,10 @@ class WFSSConfig(dict):
         -------
         None
         """
-        self.theta = np.radians(theta)
-        self.cos = np.cos(theta)
-        self.sin = np.sin(theta)
-
+        self.theta = theta
+        self.cos = np.cos(np.radians(self.theta))
+        self.sin = np.sin(np.radians(self.theta))
+        
     def add_rotation(self, dtheta):
         """
         Method to update the current spectral dispersion  rotation angle
@@ -120,7 +120,7 @@ class WFSSConfig(dict):
         -------
         None
         """
-        self.set_rotation(self.theta + np.radians(dtheta))
+        self.set_rotation(self.theta + dtheta)
 
     def set_shift(self, dx, dy):
         """
@@ -249,9 +249,8 @@ class WFSSConfig(dict):
         """
 
         dx, dy = self[order].deltas(x0, y0, wav)
-
-        x = x0 + self.xshift + self.cos * dx + self.sin * dy
-        y = y0 + self.yshift - self.sin * dx + self.cos * dy
+        x = x0 + self.xshift + self.cos * dx - self.sin * dy
+        y = y0 + self.yshift + self.sin * dx + self.cos * dy
 
         return x, y
 
@@ -339,7 +338,6 @@ class WFSSConfig(dict):
                             # save the recast value
                             values.append(value)
                         if len(values) == 1:
-
                             # if there is only one value, the pop it. else
                             # convert to a np array
                             if isinstance(values[0], str):

--- a/slitlessutils/core/wfss/data/wfss.py
+++ b/slitlessutils/core/wfss/data/wfss.py
@@ -478,9 +478,11 @@ class WFSSDetector:
         """
 
         if forward:
-            X, Y = wcs.all_world2pix(*self.wcs.all_pix2world(x, y, 0), 0)
+            #X, Y = wcs.all_world2pix(*self.wcs.all_pix2world(x, y, 0), 0)
+            X, Y = wcs.wcs_world2pix(*self.wcs.wcs_pix2world(x, y, 0), 0)
         else:
-            X, Y = self.wcs.all_world2pix(*wcs.all_pix2world(x, y, 0), 0)
+            #X, Y = self.wcs.all_world2pix(*wcs.all_pix2world(x, y, 0), 0)
+            X, Y = self.wcs.wcs_world2pix(*wcs.wcs_pix2world(x, y, 0), 0)
         return X, Y
 
     def ad2xy(self, a, d):
@@ -806,7 +808,9 @@ class WFSS(dict):
                 obj.visit = s[0]
                 obj.orbit = int(s[1])
         elif tel == 'JWST':
-            raise NotImplementedError('gotta get VISIT, ORBIT, SUBARRAY for JWST')
+            obj.visit = phdr['VISIT']
+            obj.orbit = 0
+            obj.subarray = False
         else:
             LOGGER.error(f'Telescope ({tel}) is not found to get visit')
 

--- a/slitlessutils/core/wfss/data/wfss.py
+++ b/slitlessutils/core/wfss/data/wfss.py
@@ -478,10 +478,10 @@ class WFSSDetector:
         """
 
         if forward:
-            #X, Y = wcs.all_world2pix(*self.wcs.all_pix2world(x, y, 0), 0)
+            # X, Y = wcs.all_world2pix(*self.wcs.all_pix2world(x, y, 0), 0)
             X, Y = wcs.wcs_world2pix(*self.wcs.wcs_pix2world(x, y, 0), 0)
         else:
-            #X, Y = self.wcs.all_world2pix(*wcs.all_pix2world(x, y, 0), 0)
+            # X, Y = self.wcs.all_world2pix(*wcs.all_pix2world(x, y, 0), 0)
             X, Y = self.wcs.wcs_world2pix(*wcs.wcs_pix2world(x, y, 0), 0)
         return X, Y
 


### PR DESCRIPTION
This PR address four separate bugs:

1. wfssconfig: FWCPOS should a scalar, but config code reads in as a 1-element vector.  So need [0].  Also, the rotation is applied in reverse, so a negative sign is misplaced on the rotation matrix
2. wfss: orbit/subarray are not getting set correctly.  Change all to WCS only transformations.  This is because things fail for images that are far apart.
3. region: many changes had to happen. It was incorrectly assumed that segmentation regions were "singles" (meaning that all of the pixels associated with an ID would be connected), but this is not true in practice where some bits might be related to the same ID but not connected.  This fixes that error.  This amounts to needing a loop over regions, where before things just indexing the 0th element.
4. single: the default values for some keywords were not getting set properly.  This fixes that.