### PR TITLE
the out-of-field condition returns wrong data type, this fixes that

### DIFF
--- a/slitlessutils/core/wfss/config/instrumentconfig.py
+++ b/slitlessutils/core/wfss/config/instrumentconfig.py
@@ -549,22 +549,26 @@ class DetectorConfig:
 
         # check that pixel is disperable
         if not self.config.pom(np.average(x0), np.average(y0)):
-            return [], [], [], []
+            x = np.array([], dtype=np.int32)
+            y = np.array([], dtype=np.int32)
+            lam = np.array([], dtype=np.uint16)
+            area = np.array([], dtype=float)
+        else:
 
-        # disperse the pixel
-        xg, yg = self.config.disperse(x0, y0, order, wav)
+            # disperse the pixel
+            xg, yg = self.config.disperse(x0, y0, order, wav)
 
-        # truncate pixels to be in the grid (move this into pypolyclip?)
-        xg = np.clip(xg - 0.5, 0, self.naxis[0] - 1)
-        yg = np.clip(yg - 0.5, 0, self.naxis[1] - 1)
-
-        # clip against the pixel grid
-        x, y, area, slices = clip_multi(xg, yg, self.naxis)
-
-        # make wavelength indices
-        lam = np.empty_like(x, dtype=np.uint16)
-        for i, s in enumerate(slices):
-            lam[s] = i
+            # truncate pixels to be in the grid (move this into pypolyclip?)
+            xg = np.clip(xg - 0.5, 0, self.naxis[0] - 1)
+            yg = np.clip(yg - 0.5, 0, self.naxis[1] - 1)
+            
+            # clip against the pixel grid
+            x, y, area, slices = clip_multi(xg, yg, self.naxis)
+            
+            # make wavelength indices
+            lam = np.empty_like(x, dtype=np.uint16)
+            for i, s in enumerate(slices):
+                lam[s] = i
 
         return x, y, lam, area
 

--- a/slitlessutils/core/wfss/config/instrumentconfig.py
+++ b/slitlessutils/core/wfss/config/instrumentconfig.py
@@ -561,10 +561,10 @@ class DetectorConfig:
             # truncate pixels to be in the grid (move this into pypolyclip?)
             xg = np.clip(xg - 0.5, 0, self.naxis[0] - 1)
             yg = np.clip(yg - 0.5, 0, self.naxis[1] - 1)
-            
+
             # clip against the pixel grid
             x, y, area, slices = clip_multi(xg, yg, self.naxis)
-            
+
             # make wavelength indices
             lam = np.empty_like(x, dtype=np.uint16)
             for i, s in enumerate(slices):


### PR DESCRIPTION
There is an out-of-field test, which when fails returns four lists.  But if the code succeeds (ie. the pixel is in the field), then it returns four `np.array`s.  The difference in datatype can cause down stream problems.  So this just fixes the out-of-field condition to return np arrays of the same dtype as the success condition.  

