### PR TITLE
Debug CI failure due to pkg_resources deprecation warning

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,12 +31,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.9'
-            tox_env: 'py39-test'
-            allow_failure: false
-            prefix: ''
-
-          - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test'
             allow_failure: false

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -96,7 +96,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies
-      run: python -m pip install --upgrade pip setuptools tox h5py
+      run: python -m pip install --upgrade pip setuptools tox
     - name: Print Python, pip, setuptools, and tox versions
       run: |
         python -c "import sys; print(f'Python {sys.version}')"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -96,7 +96,7 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies
-      run: python -m pip install --upgrade pip setuptools tox
+      run: python -m pip install --upgrade pip setuptools tox h5py
     - name: Print Python, pip, setuptools, and tox versions
       run: |
         python -c "import sys; print(f'Python {sys.version}')"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -43,7 +43,7 @@ jobs:
             allow_failure: false
             prefix: ''
 
-          - os: macos-12
+          - os: macos-latest
             python: '3.11'
             tox_env: 'py311-test-cov'
             allow_failure: false
@@ -98,7 +98,7 @@ jobs:
     - name: Install base dependencies
       run: python -m pip install --upgrade pip setuptools tox
     - name: Brew install HDF5 on Mac
-      if: ${{ contains(matrix.tox_env, 'macos') }}
+      if: ${{ contains(matrix.os, 'macos') }}
       run: brew install hdf5
     - name: Print Python, pip, setuptools, and tox versions
       run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -43,7 +43,7 @@ jobs:
             allow_failure: false
             prefix: ''
 
-          - os: macos-latest
+          - os: macos-12
             python: '3.11'
             tox_env: 'py311-test-cov'
             allow_failure: false

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -97,6 +97,9 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies
       run: python -m pip install --upgrade pip setuptools tox
+    - name: Brew install HDF5 on Mac
+      if: ${{ contains(matrix.tox_env, 'macos') }}
+      run: brew install hdf5
     - name: Print Python, pip, setuptools, and tox versions
       run: |
         python -c "import sys; print(f'Python {sys.version}')"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ requires-python = '>=3.10'
 dependencies = [
     'astropy>=5.0.4',
     'astroquery',
-    'drizzlepac>=3.7',
     'h5py>=3.6.0',
+    'drizzlepac>=3.7',
     'networkx>=2.6.3',
     'numpy>=1.22.3',
     'matplotlib>=3.5.2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = '>=3.10'
 dependencies = [
     'astropy>=5.0.4',
     'astroquery',
-    'h5py>=3.6.0',
+    'h5py==3.10',
     'drizzlepac>=3.7',
     'networkx>=2.6.3',
     'numpy>=1.22.3',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     'pysiaf>=0.16.4',
     'scikit-image>=0.19.2',
     'scipy>=1.8.0',
-    'shapely>=1.8.2',
+    'shapely>=1.8.2,<2',
     'stsci.tools>=4.1',
     'tqdm>=4.64.0'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     'scikit-image>=0.19.2',
     'scipy>=1.8.0',
     'shapely>=1.8.2',
-    'stsci.tools<=4.1'
+    'stsci.tools<=4.1',
     'tqdm>=4.64.0'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     'scikit-image>=0.19.2',
     'scipy>=1.8.0',
     'shapely>=1.8.2',
-    'stsci.tools<=4.1',
+    'stsci.tools>=4.1',
     'tqdm>=4.64.0'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Astronomy',
 ]
 dynamic = ['version']
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
     'astropy>=5.0.4',
     'astroquery',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     'h5py==3.10',
     'drizzlepac>=3.7',
     'networkx>=2.6.3',
-    'numpy>=1.22.3',
+    'numpy>=1.22.3,<2',
     'matplotlib>=3.5.2',
     'pandas>=1.4.2',
     'psutil>=5.9.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = '>=3.9'
 dependencies = [
     'astropy>=5.0.4',
     'astroquery',
-    'drizzlepac',
+    'drizzlepac>=3.7',
     'h5py>=3.6.0',
     'networkx>=2.6.3',
     'numpy>=1.22.3',
@@ -47,6 +47,7 @@ dependencies = [
     'scikit-image>=0.19.2',
     'scipy>=1.8.0',
     'shapely>=1.8.2',
+    'stsci.tools<=4.1'
     'tqdm>=4.64.0'
 ]
 


### PR DESCRIPTION
Might just need to make sure we're pulling updated versions of drizzlepac and stsci.tools. Hopefully there are no version conflicts, I'm not sure why the most recent ones aren't getting pulled already.