### PR TITLE
Retrieve correct master background for subarray data

### DIFF
--- a/slitlessutils/core/preprocess/background/background.py
+++ b/slitlessutils/core/preprocess/background/background.py
@@ -86,6 +86,7 @@ def background_processing(mastersky=False):
                                             back_vers = 1
                                     else:
                                         back_vers = vers
+
                                     mod = fits.getdata(backfile, ('SKY', back_vers))
 
                                     a, m, s = sigma_clipped_stats(mod)

--- a/slitlessutils/core/preprocess/background/background.py
+++ b/slitlessutils/core/preprocess/background/background.py
@@ -50,17 +50,6 @@ def background_processing(mastersky=False):
                     LOGGER.warning(msg)
                     return
 
-                # check that this is *NOT* a subarray.  Eventually, we can
-                # excise the master sky image(s) and this check can be
-                # removed, but that is going to take a little more care.
-                # Specifically, the concerns will be which CCD/detector is
-                # the subarray on?  This affects the primary for-loop
-                # over the HDUL.  This shouldn't be too hard.
-                if mastersky and phdr.get('SUBARRAY', False):
-                    msg = f"Master-sky subtraction is not supported for subarrays: {filename}"
-                    LOGGER.knownissue(msg)
-                    return
-
                 # dummy variable for writing a new file
                 wrote = False
 
@@ -87,7 +76,17 @@ def background_processing(mastersky=False):
                             if mastersky:
                                 if isinstance(backfile, str) and os.path.exists(backfile):
                                     # get the model and check normalization
-                                    mod = fits.getdata(backfile, ('SKY', vers))
+                                    if phdr.get('SUBARRAY', False):
+                                        # In the subarray case, we could have both CCDCHIP and
+                                        # EXTVER both be 1, so we need to make sure we get the correct
+                                        # extension from the master background file.
+                                        if hdr['CCDCHIP'] == 1:
+                                            back_vers = 2
+                                        elif hdr['CCDCHIP'] == 2:
+                                            back_vers = 1
+                                    else:
+                                        back_vers = vers
+                                    mod = fits.getdata(backfile, ('SKY', back_vers))
 
                                     a, m, s = sigma_clipped_stats(mod)
                                     if np.abs(a - 1) > 1e-2:

--- a/slitlessutils/core/preprocess/background/background.py
+++ b/slitlessutils/core/preprocess/background/background.py
@@ -84,6 +84,10 @@ def background_processing(mastersky=False):
                                             back_vers = 2
                                         elif hdr['CCDCHIP'] == 2:
                                             back_vers = 1
+                                        # Warn that results might still be suspect
+                                        msg = ("Master-sky subtraction may give poor results for subarray"
+                                               f"data, especially for small subarrays: {filename}")
+                                        LOGGER.knownissue(msg)
                                     else:
                                         back_vers = vers
 


### PR DESCRIPTION
Subarray data might have `CCDCHIP = 1` in a `SCI` extension with `EXTVER = 1`, which would cause the current logic to retrieve the incorrect master background array. This additional check ensures that we retrieve the correct background before excising to the subarray region.