### PR TITLE
Remove windows tests from CI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -45,12 +45,6 @@ jobs:
             prefix: ''
             toxposargs: --remote-data=any
 
-          - os: windows-latest
-            python: '3.11'
-            tox_env: 'py311-test'
-            allow_failure: true
-            prefix: '(Allowed failure)'
-
           - os: ubuntu-latest
             python: '3.11'
             tox_env: 'py311-test'


### PR DESCRIPTION
A key dependency of this package is `drizzlepac`, but that package (and it's dependents like `stregion`) do not build windows wheels, causing the windows test to fail.

* https://pypi.org/project/drizzlepac/#files
* https://pypi.org/project/stregion/#files