### PR TITLE
Fix numpy 2.0 issues

### DIFF
--- a/slitlessutils/core/tables/attributes.py
+++ b/slitlessutils/core/tables/attributes.py
@@ -89,6 +89,6 @@ def write(h5, key, val):
 
     if val is not None:
         if isinstance(val, (bool, str)):
-            h5.attrs[key] = np.string_(val)
+            h5.attrs[key] = np.bytes_(val)
         else:
             h5.attrs[key] = val

--- a/slitlessutils/core/utilities/indices.py
+++ b/slitlessutils/core/utilities/indices.py
@@ -125,13 +125,11 @@ def reverse(ints, ignore=()):
 
     """
 
-    uniq, ind, cnt = np.unique(ints, return_inverse=True, return_counts=True)
+    uniq, ind, cnt = np.unique(ints.ravel(), return_inverse=True,
+                               return_counts=True)
     rev = np.split(np.argsort(ind), np.cumsum(cnt[:-1]))
 
-    # changed to this so ints can be a list
-    ri = {u: np.unravel_index(r, np.shape(ints)) for u, r in zip(uniq, rev) if u not in ignore}
-
-    return ri
+    return {u: np.unravel_index(r, np.shape(ints)) for u, r in zip(uniq, rev) if u not in ignore}
 
 
 def decimate(val, *indices, dims=None, unravel=True, return_factor=False):


### PR DESCRIPTION
The reverse indices returned by `np.unique` are no longer flattened in numpy 2.0, which caused the `indices.reverse` function fail.  Subsequent tests failed due to the use of `np.string_`, which was removed in numpy 2.0.  `np.bytes_` is the replacement.

The latest version of `drizzlepac` requires `numpy 2.0+`, so we should probably make that the required min version.

The ACS grism test still fails due to the results not matching the expected results.  The WR96 example also now runs to completion, but the results also do not match the expected results.