### PR TITLE
Update python requirement in installation instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,7 +16,7 @@ Start by creating an empty conda environment:
 
 .. code-block:: bash
 
-    conda create --name slitlessutils-env "python>=3.10, <3.11"
+    conda create --name slitlessutils-env "python>=3.11"
     conda activate slitlessutils-env
 
 


### PR DESCRIPTION
We now require >=3.11, the install instructions needed to be updated to reflect this.