### PR TITLE
Add numba fix to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ To install the latest development version of this repository, please use:
 pip install git+https://github.com/spacetelescope/slitlessutils.git
 ```
 
+You may run into an error building `llvmlite`, a dependency of `numba` (used to increase performance in `slitlessutils`) during installation.
+This can be fixed by running `conda install --channel=numba llvmlite` in your conda environment before installing `slitessutils`.
+
 You also need to obtain the calibration (reference) files, which are stored in a public box folder, which can be done with the slitlessutils config objects.  Please see [configuring slitlessutils](https://slitlessutils.readthedocs.io/en/latest/configure.html)
 for instructions and examples.  Please see our [documentation](https://slitlessutils.readthedocs.io/en/latest/install.html)
 for additional installation instructions and/or methods.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,6 +19,11 @@ Start by creating an empty conda environment:
     conda create --name slitlessutils-env "python>=3.11"
     conda activate slitlessutils-env
 
+You may also need to manually install precompiled ``llvmlite`` binaries before installing
+``slitlessutils`` to avoid an error when building ``numba`` (used by ``slitlessutils`` to
+improve performance) during the installation. This can be done by running ``conda install --channel=numba llvmlite``
+in your conda environment before installing ``slitessutils``.
+
 
 Installing ``slitlessutils``
 ----------------------------


### PR DESCRIPTION
@bjkuhn ran into a build error when installing the most recent dev version of slitlessutils. These instructions should fix the error he ran into.