### PR TITLE
Multiorient2

### DIFF
--- a/slitlessutils/core/modules/extract/multi/lcurve.py
+++ b/slitlessutils/core/modules/extract/multi/lcurve.py
@@ -47,6 +47,9 @@ class LCurve:
     def __str__(self):
         return str(self.data)
 
+    def __bool__(self):
+        return len(self.data) > 0
+
     def clear(self):
         """
         Method to clear this L-curve object from all its data
@@ -168,6 +171,9 @@ class LCurve:
 
         """
 
+        if not self:
+            return
+
         # get the colormap and lighten it
         cmap = plt.cm.get_cmap(colormap)
         cmap = self.remap_cmap(lambda x: lighten * (1. + x), cmap)
@@ -176,7 +182,9 @@ class LCurve:
         self.compute_curvature()
 
         # some plot windows
-        fig, (ax1, ax2) = plt.subplots(2, 1, gridspec_kw={'height_ratios': [0.8, 1.]})
+        gridspec_kw = {'height_ratios': [0.8, 1.]}
+        fig, (ax1, ax2) = plt.subplots(2, 1, gridspec_kw=gridspec_kw,
+                                       figsize=(5, 5))
 
         # show the group ID
         if grpid is not None:
@@ -198,15 +206,14 @@ class LCurve:
         # line = ax1.plot(self.data['logchi2'], self.data['lognorm'], '-k',
         ax1.plot(logchi2, lognorm, '-k', linewidth=1, zorder=1)
 
-        # scat = ax1.scatter(self.data['logchi2'], self.data['lognorm'], zorder=2,
         scat = ax1.scatter(logchi2, lognorm, zorder=2,
-                           c=self.data['logdamp'], s=40, cmap=cmap, edgecolors='k',
-                           marker='o', vmin=lmin, vmax=lmax)
+                           c=self.data['logdamp'], s=40, cmap=cmap,
+                           edgecolors='k', marker='o', vmin=lmin, vmax=lmax)
 
         # put the frobenius norm in the plot
         # if self.norm is not None:
         if rescale:
-            ax1.text(0.67, 0.88, fr'$\log\ ||W||_F=${self.norm:+.3f}',
+            ax1.text(0.05, 0.08, fr'$\log\ ||W||_F=${self.norm:+.3f}',
                      horizontalalignment='left', transform=ax1.transAxes,
                      bbox=dict(facecolor='white', edgecolor='white'))
             ylabel = r'$\log\ ||W||_F^2\,||f||^2$'
@@ -214,39 +221,32 @@ class LCurve:
             ylabel = r'$\log\ ||f||^2$'
 
         # plot the labels
-        # ax1.set(xlabel=r'$\log\ ||Ax-b||^2$',
-        #        ylabel=r'$\log\ ||x||^2$')
-        ax1.set(xlabel=r'$\log\ ||Wf-{\cal I}||^2$',
-                ylabel=ylabel)
+        ax1.set(xlabel=r'$\log\ ||Wf-{\cal I}||^2$', ylabel=ylabel)
         ax1.set_axisbelow(True)
 
         # put on a grid
         ax1.grid(True)
 
         # plot the curvature
-
         ax2.plot(self.data['logdamp'], self.data['curvature'], '-k',
                  linewidth=1, zorder=1)
 
         scat = ax2.scatter(self.data['logdamp'], self.data['curvature'],
-                           zorder=3, s=40, cmap=cmap, edgecolors='k', marker='o',
-                           c=self.data['logdamp'], vmin=lmin, vmax=lmax)
+                           zorder=3, s=40, cmap=cmap, edgecolors='k',
+                           marker='o', c=self.data['logdamp'], vmin=lmin, vmax=lmax)
 
         # find and indicate the maximum
         if len(self.data) > 1:
             g = np.where(self.data['curvature'] == np.nanmax(self.data['curvature']))[0][0]
         else:
             g = 0
-            ax2.axvline(x=self.data['logdamp'][g], color='k', linestyle=':', zorder=2)
+        ax2.axvline(x=self.data['logdamp'][g], color='k', linestyle=':', zorder=2)
 
         # set the xrange
-        if lmax == lmin:
-            if np.isfinite(lmax):
-                ax2.set_xlim([lmin - 0.5, lmax + 0.5])
-            else:
-                ax2.set_xlim([-5, 0])
-        else:
-            ax2.set_xlim([lmin, lmax])
+        xlim = (-5, 0)   # default
+        if np.isfinite(lmin) and np.isfinite(lmax) and (lmin != lmax):
+            xlim = (lmin - 0.5, lmax + 0.5)
+        ax2.set_xlim(xlim)
 
         # label the axes
         ax2.set(ylabel='curvature')

--- a/slitlessutils/core/modules/extract/multi/matrix.py
+++ b/slitlessutils/core/modules/extract/multi/matrix.py
@@ -1,56 +1,21 @@
+from collections import namedtuple
+
 import numpy as np
-from scipy.sparse import coo_matrix, linalg
+from scipy import sparse
 from tqdm import tqdm
 
 from .....config import Config
 from .....logger import LOGGER
 from ....tables import PDTFile
-from ....utilities import as_iterable, headers, indices
+from ....utilities import as_iterable, headers  # , indices
 from .lcurve import LCurve
 from .result import Result
 
-# Just for notation sake
-# variables with a 'g' are in the WFSS image
-#                a 'u' are unique versions (so duplicates have been removed
-#                      or summed over as applicable)
-#                'comp' are compressed over the indices
-#                'uniq' are uniq such that this is true: i=iuniq[icomp].
-#                       which means that max(icomp)=len(iuniq)
-# pixel coordinates will be represented as either 1-d pixels (xyg) or
-# a 2-d pixel pair (xg,yg).  This is because 1d coordinates are easier to
-# work with in terms of summations, but harder when retrieving pixel
-# values out of an image
+
+ImageData = namedtuple("ImageData", ['dataset', 'detname', 'pixels'])
 
 
 class Matrix:
-    """
-    Class to implement the linear operator
-
-    Parameters
-    ----------
-    extorders : str or list
-       The spectral orders to extract.  If a list, tuple or set, then
-       multiple orders will aggregated.
-
-    mskorders : str or list or None, optional
-       The spectral orders to mask in the extraction.  If a list, tuple,
-       or set, then the multiple orders will be masked.
-
-    invmethod : str, optional
-       The inversion algorithm, options are 'lsqr' or 'lsmr'.  In general,
-       the LSMR algorithm is supposed to be faster, however it has not
-       been as thoroughly tested LSQR in this context.  Default is 'lsqr'
-
-    path : str, optional
-       The path where the HDF5 tables are stored.  Default is 'tables'
-
-    minunc : float, optional
-       The minimum value of the uncertainty.  This is to avoid divide by
-       zero errors and infinite signal-to-noise.  Default is 1e-10
-    """
-
-    INT = np.uint64     # DO NOT CHANGE THIS
-    FLOAT = np.float64  # DO NOT CHANGE THIS
 
     def __init__(self, extorders, **kwargs):
         # extract the defaults
@@ -73,33 +38,143 @@ class Matrix:
         return self.A.A.nnz if self else 0
 
     def __bool__(self):
-        return hasattr(self, 'A')
+        return hasattr(self, 'A') and (self.A.A.nnz > 0)
 
     def __str__(self):
         return f'Sparse matrix with {len(self)} elements'
 
-    def build_matrix(self, data, sources, group=0):
-        """
-        Method to build a matrix
+    def load_image_matrix(self, h5, detdata, sources, gpx):
+        '''
+        Load a CSR matrix for a given WFSS image
 
-        Parameters
-        ----------
-        data : `WFSSCollection`
-            The WFSS data to make into a matrix
+        Inputs
+        ------
+        h5 : h5py file object
+            The file to load the table from
+
+        detdata : `WFSSDetector`
+            The detector to load the table for
 
         sources : `SourceCollection`
-            The sources to build the matrix for
+            The source collection for this image
 
-        group : int, optional
-            The group ID.  Default is 0
+        gpx : `np.ndarray`
+            A mask of good pixels
 
-        Notes
-        -----
-        1) This is the heart-and-soul of the multi-ended spectral extraction
-        2) This operation can be very slow, but has been optimized to
-           be efficient in its memory usage.
+        Returns
+        -------
+        A : `scipy.sparse.csr_matrix`
+            The CSR sparse matrix for this image
 
-        """
+        yx : tuple of `np.ndarray`s
+            The pixel coordinates in the WFSS image for which we have data
+
+        '''
+
+        # will need this
+        npix = detdata.npixels()
+
+        # get the flat field
+        flatfield = detdata.config.load_flatfield()
+
+        # a container to hold all the submatrices
+        A = []
+        for ordname in self.extorders:
+            h5.load_order(ordname)
+            sensitivity = detdata.config[ordname].sensitivity
+
+            for source in sources.values():
+
+                # get the extration properties for this source
+                if hasattr(source, 'extpars'):
+                    extpars = source.extpars
+                else:
+                    extpars = self.defpars
+
+                # fetch the limits and the number of elements
+                limits = extpars.limits()
+                nlam = len(extpars)
+
+                # the dimensionality of this local submatrix
+                shape = (npix, nlam)
+
+                for regidx, region in enumerate(source):
+                    tab = h5.load_odt(region)
+                    if tab:
+                        wav = tab.wavelengths()
+                        x = tab.get('x', dtype=int)
+                        y = tab.get('y', dtype=int)
+                        val = tab.get('val')
+
+                        # remove badpixels
+                        g = np.where(gpx[y, x])[0]
+                        if g.size > 0:
+                            wav = wav[g]
+                            x = x[g]
+                            y = y[g]
+                            val = val[g]
+
+                            # matrix coordinates
+                            i = np.ravel_multi_index((y, x), dims=detdata.shape)
+                            j = np.digitize(wav, limits) - 1
+
+                            # compute weights
+                            sens = sensitivity(wav) * self.fluxscale
+                            flat = flatfield(x, y, wav)
+                            area = detdata.relative_pixelarea(x, y)
+
+                            # apply calibs to the weights
+                            aij = (val * sens * flat * area)
+
+                            # make the local sparse matrix
+                            Asub = sparse.csr_matrix((aij, (i, j)), shape=shape)
+
+                        else:
+                            # create an empty matrix in case all pixels got
+                            # masked out for whatever reason
+                            Asub = sparse.csr_matrix(shape)
+
+                    else:
+                        # create an empty matrix for objects out of the field
+                        Asub = sparse.csr_matrix(shape)
+
+                    # save it to the list, so we can stack them later
+                    A.append(Asub)
+
+        # stack all the sparse matrices
+        A = sparse.hstack(A)
+
+        # find the rows that are all zero
+        yx = np.where(np.diff(A.indptr))[0]
+
+        # remove the zero rows
+        A = A[yx]
+
+        # get the image coordinates
+        y, x = np.unravel_index(yx, shape=detdata.shape)
+
+        return A, (y, x)
+
+    def build_matrix(self, data, sources, group=0):
+        '''
+        Build a sparse matrix and ancillary data
+
+        Inputs
+        ------
+        data : `WFSSCollection`
+            The WFSS data
+
+        sources : `SourceCollection`
+            The sources to extract
+
+        grpid : int
+            The group that these sources refer to.  Default=0
+
+        Returns
+        -------
+        None
+
+        '''
 
         # do some quick checks
         if not self.extorders:
@@ -114,65 +189,32 @@ class Matrix:
         self.nfiles = len(data)
         self.nsources = len(sources)
         self.segids = list(sources.keys())
-
-        # get the extraction parameters
         self.defpars = data.get_parameters()
-        nwave = len(self.defpars)
 
-        # compute the cumulative number of wavelength elements
-        # this is to deal with uneven numbers of wavelength elements
-        self.cumlam = [0]
-        self.sedkeys = []         # to know which source/region goes with output
-        for segid, source in sources.items():
+        # issue a message
+        LOGGER.info("Building matrix with\n" +
+                    f"       WFSS files: {self.nfiles}\n" +
+                    f"          Sources: {self.nsources}\n" +
+                    f"         Group ID: {self.group}")
 
-            if hasattr(source, 'extpars'):
-                nw = len(source.extpars)
-            else:
-                nw = nwave
-
-            for sedkey, sedreg in source.items():
-                self.cumlam.append(self.cumlam[-1] + nw)
-                self.sedkeys.append(sedkey)
-        self.cumlam = np.array(self.cumlam, dtype=int)
-
-        # compute number of knowns (ie. total number of pixels) and
-        # unknowns (ie. total number of wavelengths
-        self.nknowns = data.npixels()     # total number of knowns
-        self.nunknowns = self.cumlam[-1]    # total number of unknowns
-
-        # record this value so we can make residuals
+        # lists for output data
+        # b = A.x, so b, and A are the linear variables
+        # pixels is a list of all the image pixels we've swept up
+        self.A = []
+        self.b = []
         self.imgdata = []
 
-        # print a message
-        LOGGER.info('Building a matrix\n' +
-                    f'      WFSS files: {self.nfiles}\n' +
-                    f'      Sources:     {self.nsources}\n' +
-                    f'      Unknowns:    {self.nunknowns}\n' +
-                    f'      Knowns:      {self.nknowns}')
-
-        # lists to save the matrix content
-        self.i = []     # knowns coordinate in matrix
-        self.j = []     # unknowns coordinate in matrix
-        self.aij = []   # matrix elements
-        self.bi = []    # vector of known values
-
         # process each WFSS image
-        self.detindex = 0
-        for datum in tqdm(data, desc='Loading WFSS Images', total=self.nfiles,
+        for datum in tqdm(data, desc="Loading WFSS Images", total=self.nfiles,
                           dynamic_ncols=True):
 
             # load the data for this WFSS image
             with PDTFile(datum, path=self.path, mode='r') as h5:
 
-                for detname, detdata in datum.items():
+                for detindex, (detname, detdata) in enumerate(datum.items()):
                     h5.load_detector(detname)
-                    flatfield = detdata.config.load_flatfield()
 
-                    # record which pixels were used for this detector,
-                    # this will be used later to get the unique pixels
-                    self.xyg = []
-
-                    # read the actual images
+                    # read the images
                     sci, hdr = detdata.readfits('science', header=True)
                     unc = detdata.readfits('uncertainty')
                     dqa = detdata.readfits('dataquality')
@@ -185,258 +227,107 @@ class Matrix:
                         sci /= time
                         unc /= time
 
-                    # make a good-pixel mask (gpx)
+                    # initialize a good-pixel mask as the pixels that are finite
+                    gpx = np.isfinite(sci) & np.isfinite(unc)
+
+                    # update the good-pixel mask with a bitmask
                     if detdata.config.bitmask:
-                        gpx = np.bitwise_and(dqa, detdata.config.bitmask) == 0
-                    else:
-                        gpx = np.ones_like(dqa, dtype=bool)
+                        gpx &= (np.bitwise_and(dqa, detdata.config.bitmask) == 0)
 
-                    # save the image dimensionalities
-                    if not hasattr(self, 'imgdim'):
-                        self.imgdim = tuple(reversed(sci.shape))
+                    # if detdata.config.bitmask:
+                    #    gpx = np.bitwise_and(dqa, detdata.config.bitmask) == 0
+                    # else:
+                    #    gpx = np.ones_like(dqa, dtype=bool)
 
-                    # update msk for the mskorders
+                    # this will work, but maybe less efficient?
+                    # bad = np.logical_not(np.isfinite(sci) & np.isfinite(unc))
+                    # gpx[bad] = False
+
+                    # update the mask for the mask orders
                     for ordname in self.mskorders:
                         h5.load_order(ordname)
                         for source in sources.values():
                             omt = h5.load_omt(source)
                             gpx[omt.get('y'), omt.get('x')] = False
 
-                    # read each order to extract
-                    for ordname in self.extorders:
-                        h5.load_order(ordname)
+                    # load all the submatrices for each order
+                    Aimg, yx = self.load_image_matrix(h5, detdata, sources, gpx)
 
-                        # set a variable that will be updated in subroutine
-                        self.srcindex = 0
+                    # grab the pixel values from data and uncertainty
+                    # but NB: the unc could potentially be zero, which will
+                    # cause problems with weighting by inverse-variance.
+                    # so the value minunc will set the minimum uncertainty
+                    # to avoid this problem
+                    s = sci[yx]
+                    u = np.maximum(unc[yx], self.minunc)
 
-                        # process each source
-                        for source in sources.values():
+                    # normalize the data and matrices by the uncertainties
+                    # for inverse-variance weighting of the solution (ie.
+                    # solving maximum likelihood).  But will change to a
+                    # column matrix for latter use
+                    Aimg /= u[:, np.newaxis]
+                    s /= u
 
-                            for region in source:  # .spectralregions:
-                                # read the table
-                                tab = h5.load_odt(region)
-                                if tab:
-                                    self._parse_table(tab, source, unc, gpx,
-                                                      ordname, detdata, flatfield)
+                    # save the data and matrices
+                    self.b.extend(s)
+                    self.A.append(Aimg.tocsc())
 
-                    # ok.  At this point, we've loaded all the data for
-                    # a WFSS detector.  But let's verify that there are
-                    # actually good pixels
-                    if self.xyg:
-                        # now must get the unique pixels from the observations
-                        self.xyg = np.unique(self.xyg)
+                    # save some light-weight things about this image
+                    imgdata = ImageData(datum.dataset, detname, yx)
+                    self.imgdata.append(imgdata)
 
-                        # compute the 2d pixel coordinates
-                        xg, yg = np.unravel_index(self.xyg, detdata.naxis, order='F')
+        # store things in a way to use later
+        self.A = sparse.linalg.aslinearoperator(sparse.vstack(self.A))
+        self.b = np.asarray(self.b)
+        self.frob = sparse.linalg.norm(self.A.A)
 
-                        # grab the observations and weight by uncertainty
-                        # (basically just the signal-to-noise)
-                        bi = sci[yg, xg] / np.maximum(unc[yg, xg], self.minunc)
+        # make a mask for spectral elements that have no constraints in the
+        # data, which corresponds to columns that are all zero
+        self.unconstrained = (np.diff(self.A.A.indptr) == 0)
 
-                        # save the results
-                        self.bi.extend(bi)
-
-                        # record the image info to make residual images later
-                        self.imgdata.append((datum.dataset, detname))
-
-                        # increment -- could just use len(self.imgdata)
-                        self.detindex += 1
-
-        # ok.  AT this point, we've loaded all the matrix data for the images
-        #      but we'll need to do some juggling to best use the memory
-        #      and computational resources
-
-        # first we need to compress over the indices, which can be slow
-        # so we'll print a message
-        LOGGER.info('Compressing indices')
-        self.icomp, self.iuniq = indices.compress(self.i)
-        self.i.clear()          # delete the data
-
-        self.jcomp, self.juniq = indices.compress(self.j)
-        self.j.clear()
-
-        # get some dimensionalities
-        self.npix = len(self.iuniq)
-        self.npar = len(self.juniq)
-        dim = np.array([self.npix, self.npar], int)   # dimensionality of matrix
-
-        # do a sanity check
-        if np.amax(self.icomp) != len(self.bi) - 1:
-            msg = f'Matrix has invalid dimensionlity: ({self.npix}\u00d7{self.npar})'
-            LOGGER.error(msg)
-            raise RuntimeError(msg)
-
-        # recast the vector
-        self.bi = np.array(self.bi, dtype=float)
-
-        # do some more checks
-        if not self.overdetermined:
-            dimlab = f"{self.npix}\u00d7{self.npar}"
-            msg = f"Underdetermined matrix: ({dimlab}).\nResults will be dubious"
-            LOGGER.warning(msg)
-
-        # compute some extra things for the ragged arrays (ie. where
-        # sources can have different number of spectral elements)
-        # and there are tuples lurking to describe (segid,regid).  Will
-        # call this as an extind for extraction index
-        if self.nsources == 1:
-            extind = np.zeros(self.npar, dtype=self.juniq.dtype)
+        # set some variables
+        self.npix, self.npar = self.A.shape
+        nel = self.npix * self.npar
+        if nel == 0:
+            self.density = np.nan
         else:
-            extind = np.digitize(self.juniq, self.cumlam) - 1
+            self.density = float(self.A.A.nnz) / nel
 
-        try:
-            self.lamids = self.juniq - self.cumlam[extind]
-
-        except BaseException:
-            LOGGER.debug(self.npix, self.npar, self.nsources)
-            raise RuntimeError("Matrix calculation has failed")
-
-        # get the indices to do all reverse calculations
-        self.ri = indices.reverse(extind)
-
-        # compute the density of the matrix
-        self.density = float(len(self.aij)) / float(dim[0] * dim[1])
-
-        # ok ok ok... NOW make a matrix
-        self.A = coo_matrix((self.aij, (self.icomp, self.jcomp)), shape=dim)
-        self.aij.clear()
-
-        # compute the norm
-        self.frob = linalg.norm(self.A)
-
-        # make it a linear operator
-        self.A = linalg.aslinearoperator(self.A)
-
-        # compute the Frobenius norm and initialize the LCurve
+        # build an L-Curve object to store the data
         self.lcurve = LCurve(norm=self.frob)
 
-        # now do a default damping target
-        LOGGER.debug('damping target might be suspect for 2d objects')
-        LOGGER.info("Building Damping Target")
+        if self:
+            # build a target spectrum
+            target = []
+            for segid, source in sources.items():
+                if hasattr(source, 'extpars'):
+                    waves = source.extpars.wavelengths()
+                else:
+                    waves = self.defpars.wavelengths()
 
-        target = np.zeros(self.nunknowns, dtype=float)
-        for segid, source in sources.items():
+                for regid, region in source.items():
+                    target.extend(region.sed(waves))
 
-            for sedkey, region in source.items():
-                extid = self.sedkeys.index(sedkey)
-                if extid in self.ri:
-                    g1 = self.ri[extid]
-                    g2 = self.lamids[g1]
+            target = np.asarray(target)
+            if len(target) != self.npar:
+                LOGGER.error("Invalid target spectrum")
+                exit()
 
-                    if hasattr(source, 'extpars'):
-                        waves = source.extpars.wavelengths()
-                    else:
-                        waves = self.defpars.wavelengths()
-
-                    target[g1] = region.sed(waves[g2])
-
-        self.set_damping_target(target)
-
-        # just update the printing...
-        LOGGER.info('Finished building a matrix')
-
-    def _parse_table(self, tab, source, unc, gpx, ordname, detdata, flatfield):
-        """
-        Helper function to parse data from a table
-
-        Parameters
-        ----------
-        tab : `su.tables.HDF5Table`
-            The table from which the data are taken
-
-        source : `su.sources.Source`
-            The source for which the table is to be read
-
-        unc : `np.ndarray`
-            The uncertainties from the image
-
-        gpx : `np.ndarray`
-            The good-pixel table
-
-        ordname : str or int
-            The name of the spectral order
-
-        detdata : `DetectorConfig`
-            The detector for which to parse the table
-
-        flatfield : `su.core.wfss.config.FlatField`
-            The flat field object to use
-
-
-        Notes
-        -----
-        This is an internal helper function and should not really be
-        explicitly called by a user.
-        """
-
-        # compute the wavelengths
-        wav = tab.wavelengths()
-        x = tab.get('x', dtype=int)
-        y = tab.get('y', dtype=int)
-        val = tab.get('val')
-
-        # remove any bad elements
-        g = np.where(gpx[y, x])[0]
-
-        x = x[g]
-        y = y[g]
-        val = val[g]
-
-        # compute some things to rescale the matrix values
-        # 1) sensitivity curve
-        # 2) flat field
-        # 3) pixel-area map (PAM)
-        # 4) uncertainty
-        sens = detdata.config[ordname].sensitivity(wav) * self.fluxscale
-        flat = flatfield(x, y, wav)
-        area = detdata.relative_pixelarea(x, y)
-        uval = np.maximum(unc[y, x], self.minunc)     # set the uncertaint floor
-
-        # rescale the tables' values
-        val *= (sens * flat * area / uval)
-
-        # group the wavelength indices according to the extraction settings
-        # NB: the -1 is because digitize is 1-indexed, but arrays are
-        #     0-indexed, so gotta shift it back
-        if hasattr(source, 'extpars'):
-            ll = np.digitize(wav, source.extpars.limits()) - 1
+            # set the damping target
+            self.set_damping_target(target)
         else:
-            ll = np.digitize(wav, self.defpars.limits()) - 1
+            LOGGER.warning('The matrix is empty, no calculations possible.')
 
-        # compute the knowns index (called 'i' above).  First compute a
-        # i-index offset based on number of pixels to add it here, but
-        # will need to subtract it off below.
-        ii0 = detdata.npixels() * self.detindex
-        ii = np.ravel_multi_index((x, y), dims=detdata.naxis, order='F') + ii0
+        LOGGER.info("Finished building matrix")
 
-        # compute the unknowns index (called 'j' above), but gotta take
-        # extra care here if there a different number of wavelength
-        # elements per source.
-        jj = ll + self.cumlam[self.srcindex]
-
-        # decimate over the matrix coordinates --- meaning, sum over
-        # repeated matrix indices (ii,jj).  This will leave only the
-        # unique pairs of (i,j), hence the 'u' designation
-        vu, iu, ju = indices.decimate(val, ii, jj, dims=(self.nknowns, self.nunknowns))
-
-        # get the WFSS-pixel coordinates (subtracting the offset as promised)
-        xygu = indices.uniq(iu - ii0)
-
-        # save all these values and increment a global counter
-        self.i.extend(list(iu))
-        self.j.extend(list(ju))
-        self.aij.extend(list(vu))
-        self.xyg.extend(list(xygu))
-        self.srcindex += 1
-
-    def compute_model(self, xj):
+    def compute_model(self, x):
         """
         Method to compute the model, which is given as a matrix-product
         between this object and a vector of spectral values
 
         Parameters
         ----------
-        xj : `np.ndarray`
+        x : `np.ndarray`
            An array of spectra that have been concatenated in the same way
            that this `Matrix` was created.  This is used to estimate the
            expected signal on the detector(s) given a known spectrum
@@ -461,29 +352,19 @@ class Matrix:
         set of spectra
 
         """
+
+        mod = {}
         if self:
+            b = self.A.matvec(x)
 
-            bi = self.A.matvec(xj)
+            s = slice(0, 0)
+            for imgdata in self.imgdata:
+                s = slice(s.stop, s.stop + len(imgdata.pixels[0]))
 
-            npix = self.imgdim[0] * self.imgdim[1]
+                key = (imgdata.dataset, imgdata.detname)
+                mod[key] = list(zip(imgdata.pixels[0], imgdata.pixels[1], b[s]))
 
-            imgindices, pixindices = np.divmod(self.iuniq, npix)
-
-            dtype = [('x', np.uint16), ('y', np.uint16), ('v', np.float64)]
-
-            out = {image: dict() for (image, detname) in self.imgdata}
-            for imgindex, (image, detname) in enumerate(self.imgdata):
-
-                g = np.where(imgindices == imgindex)
-
-                y, x = np.divmod(pixindices[g], self.imgdim[0])
-
-                out[image][detname] = np.array(list(zip(x, y, bi[g])), dtype=dtype)
-
-        else:
-            out = None
-
-        return out
+        return mod
 
     def set_damping_target(self, target):
         """
@@ -497,43 +378,16 @@ class Matrix:
         """
         if self:
             self.target = target / self.fluxscale
-            self.bi -= self.A.matvec(self.target)
+            self.b -= self.A.matvec(self.target)
         else:
             LOGGER.warning("Cannot set damping target until matrix is built")
 
-    # some flagging parameters
+    # --------------------------------------------------------------------
+    #
+    #              functions for solving the linear problem
+    #
+    # --------------------------------------------------------------------
 
-    @property
-    def underdetermined(self):
-        return self.npar > self.npix
-
-    @property
-    def determined(self):
-        return self.npar == self.npix
-
-    @property
-    def overdetermined(self):
-        return self.npar < self.npix
-
-    @property
-    def invmethod(self):
-        return self._invmethod
-
-    @invmethod.setter
-    def invmethod(self, invmethod):
-        im = invmethod.lower()
-        if im == 'lsqr':
-            self._invfunc = self._lsqr
-            self._invmethod = im
-        elif im == 'lsmr':
-            self._invfunc = self._lsmr
-            self._invmethod = im
-        else:
-            LOGGER.warning(f'{invmethod=} is not supported. Using `LSQR`')
-            self._invfunc = self._lsqr
-            self._invmethod = 'lsqr'
-
-    # stuff for inversions
     def invert(self, logdamp, scale=True, **kwargs):
         """
         Method to the matrix inversion
@@ -604,11 +458,11 @@ class Matrix:
 
         """
 
-        r = linalg.lsqr(self.A, self.bi, damp=damp, calc_var=True, **kwargs)
+        r = sparse.linalg.lsqr(self.A, self.b, damp=damp, calc_var=True, **kwargs)
         (x, istop, itn, r1norm, r2norm, anorm, acond, arnorm, xnorm, var) = r
 
-        r = Result('LSQR', x, istop, itn, r1norm, r2norm, anorm, acond, arnorm, xnorm,
-                   np.sqrt(var), damp)
+        r = Result('LSQR', x, istop, itn, r1norm, r2norm, anorm, acond,
+                   arnorm, xnorm, np.sqrt(var), damp)
 
         return r
 
@@ -636,40 +490,60 @@ class Matrix:
 
         """
 
-        (x, istop, itn, norm, arnorm, anorm, acond, xnorm) = linalg.lsmr(self.A, self.bi,
-                                                                         damp=damp, **kwargs)
+        r = sparse.linalg.lsmr(self.A, self.b, damp=damp, **kwargs)
+        (x, istop, itn, norm, arnorm, anorm, acond, xnorm) = r
+
         r1norm = arnorm
         r2norm = np.sqrt(arnorm**2 + (damp * xnorm)**2)
         unc = np.full_like(x, np.nan)
-        r = Result('LSMR', x, istop, itn, r1norm, r2norm, anorm, acond, arnorm, xnorm,
-                   unc, damp)
+        r = Result('LSMR', x, istop, itn, r1norm, r2norm, anorm, acond,
+                   arnorm, xnorm, unc, damp)
+
         return r
 
     def compute_uncertainty(self):
-        """
-        Function to compute the uncertainties
+        ones = np.ones_like(self.b, dtype=float)
+        A2 = self.A.A.copy()
+        A2.data = np.square(A2.data)
 
-        Notes
-        -----
-        The presence of damping means that the inversion algorithms
-        (either LSQR or LSMR) will generate uncertainties that are too small
-        as they are estimating diagonals of an altered matrix (Abar).
-        See the documentation for LSQR and the `calc_var` parameter
-        for a description of that altered matrix.  Therefore, this method
-        estimates the diagonal elements of AT.A and inverting them. This is
-        not explicitly correct, as we need the diagonal elements of (AT.A)-1.
+        r = sparse.linalg.lsqr(A2, ones)
+        return np.sqrt(r[0])
 
-        """
-        LOGGER.warning("Uncertainties are not exact in `matrix.py`")
+    # --------------------------------------------------------------------
+    #
+    #                      some properites
+    #
+    # --------------------------------------------------------------------
 
-        aij2, j = indices.decimate(self.A.A.data * self.A.A.data,
-                                   self.juniq[self.jcomp])
+    @property
+    def is_underdetermined(self):
+        return self.npar > self.npix
 
-        # these two lines to avoid divide-by-zero errors
-        unc = np.full_like(aij2, np.inf)
-        np.divide(1., np.sqrt(aij2), out=unc, where=(aij2 != 0))
+    @property
+    def is_determined(self):
+        return self.npar == self.npix
 
-        return unc
+    @property
+    def is_overdetermined(self):
+        return self.npar < self.npix
+
+    @property
+    def invmethod(self):
+        return self._invmethod
+
+    @invmethod.setter
+    def invmethod(self, invmethod):
+        im = invmethod.lower()
+        if im == 'lsqr':
+            self._invfunc = self._lsqr
+            self._invmethod = im
+        elif im == 'lsmr':
+            self._invfunc = self._lsmr
+            self._invmethod = im
+        else:
+            LOGGER.warning(f'{invmethod=} is not supported. Using `LSQR`')
+            self._invfunc = self._lsqr
+            self._invmethod = 'lsqr'
 
     # --------------------------------------------------------------------
     #
@@ -692,9 +566,8 @@ class Matrix:
             return
 
         hdr['NNZ'] = (len(self), 'number of non-zero matrix elements')
-
-        hdr['NPIX'] = (self.npix, 'number of pixels analyzed (ie. knowns)')
-        hdr['NPAR'] = (self.npar, 'number of parameters measured (ie. unknowns)')
+        hdr['NPIX'] = (self.npix, 'number of pixels analyzed (knowns)')
+        hdr['NPAR'] = (self.npar, 'number of parameters measured (unknowns)')
         hdr['NDOF'] = (self.npix - self.npar, 'number of degrees of freedom')
         hdr['DENSITY'] = (self.density, 'fraction of non-zero elements')
         hdr['FROBNORM'] = (self.frob, 'Frobenius norm')
@@ -704,29 +577,3 @@ class Matrix:
         hdr['EXTORDER'] = (','.join(self.extorders), 'extraction orders')
         hdr['MSKORDER'] = (','.join(self.mskorders), 'masked orders')
         headers.add_stanza(hdr, 'Matrix Properties', before='NNZ')
-
-    # --------------------------------------------------------------------
-    #
-    #                       helper functions
-    #
-    # --------------------------------------------------------------------
-    # @staticmethod
-    # def tuplize(d):
-    #    if d is not None:
-    #        if not isinstance(d,(tuple,list)):
-    #            d=(d,)
-    #    else:
-    #        d=()
-    #    return d
-
-    # def retype(self,k,dtype):
-    #    if dtype is np.nan:
-    #        if hasattr(self,k):
-    #            return getattr(self,k)
-    #        else:
-    #            return np.nan
-    #    else:
-    #        if hasattr(self,k):
-    #            return dtype(getattr(self,k))
-    #        else:
-    #            return dtype(0)

--- a/slitlessutils/core/modules/extract/multi/matrix.py
+++ b/slitlessutils/core/modules/extract/multi/matrix.py
@@ -24,8 +24,6 @@ class Matrix:
         path = kwargs.get('path', 'su_tables')
         minunc = kwargs.get('minunc', 1e-10)
 
-        LOGGER.debug("must finish documentation")
-
         # save some things
         self.path = path
         self.invmethod = invmethod
@@ -43,7 +41,7 @@ class Matrix:
     def __str__(self):
         return f'Sparse matrix with {len(self)} elements'
 
-    def load_image_matrix(self, h5, detdata, sources, gpx):
+    def load_image_matrix(self, h5, detdata, sources, removezeros=False):
         '''
         Load a CSR matrix for a given WFSS image
 
@@ -58,16 +56,13 @@ class Matrix:
         sources : `SourceCollection`
             The source collection for this image
 
-        gpx : `np.ndarray`
-            A mask of good pixels
+        removezeros : bool
+            Flag to remove zero rows.  Default=False
 
         Returns
         -------
         A : `scipy.sparse.csr_matrix`
             The CSR sparse matrix for this image
-
-        yx : tuple of `np.ndarray`s
-            The pixel coordinates in the WFSS image for which we have data
 
         '''
 
@@ -106,33 +101,20 @@ class Matrix:
                         y = tab.get('y', dtype=int)
                         val = tab.get('val')
 
-                        # remove badpixels
-                        g = np.where(gpx[y, x])[0]
-                        if g.size > 0:
-                            wav = wav[g]
-                            x = x[g]
-                            y = y[g]
-                            val = val[g]
+                        # matrix coordinates
+                        i = np.ravel_multi_index((y, x), dims=detdata.shape)
+                        j = np.digitize(wav, limits) - 1
 
-                            # matrix coordinates
-                            i = np.ravel_multi_index((y, x), dims=detdata.shape)
-                            j = np.digitize(wav, limits) - 1
+                        # compute weights
+                        sens = sensitivity(wav) * self.fluxscale
+                        flat = flatfield(x, y, wav)
+                        area = detdata.relative_pixelarea(x, y)
 
-                            # compute weights
-                            sens = sensitivity(wav) * self.fluxscale
-                            flat = flatfield(x, y, wav)
-                            area = detdata.relative_pixelarea(x, y)
+                        # apply calibs to the weights
+                        aij = (val * sens * flat * area)
 
-                            # apply calibs to the weights
-                            aij = (val * sens * flat * area)
-
-                            # make the local sparse matrix
-                            Asub = sparse.csr_matrix((aij, (i, j)), shape=shape)
-
-                        else:
-                            # create an empty matrix in case all pixels got
-                            # masked out for whatever reason
-                            Asub = sparse.csr_matrix(shape)
+                        # make the local sparse matrix
+                        Asub = sparse.csr_matrix((aij, (i, j)), shape=shape)
 
                     else:
                         # create an empty matrix for objects out of the field
@@ -144,16 +126,18 @@ class Matrix:
         # stack all the sparse matrices
         A = sparse.hstack(A)
 
-        # find the rows that are all zero
-        yx = np.where(np.diff(A.indptr))[0]
+        if removezeros:
+            # find the rows that are all zero
+            yx = np.where(np.diff(A.indptr))[0]
 
-        # remove the zero rows
-        A = A[yx]
+            # remove the zero rows
+            A = A[yx]
 
-        # get the image coordinates
-        y, x = np.unravel_index(yx, shape=detdata.shape)
-
-        return A, (y, x)
+            # get the image coordinates
+            y, x = np.unravel_index(yx, shape=detdata.shape)
+            return A, (y, x)
+        else:
+            return A
 
     def build_matrix(self, data, sources, group=0):
         '''
@@ -214,66 +198,61 @@ class Matrix:
                 for detindex, (detname, detdata) in enumerate(datum.items()):
                     h5.load_detector(detname)
 
-                    # read the images
-                    sci, hdr = detdata.readfits('science', header=True)
-                    unc = detdata.readfits('uncertainty')
-                    dqa = detdata.readfits('dataquality')
-
-                    # adjust the units if necessary
-                    bunit = hdr.get('BUNIT', 'electron/s')
-                    if bunit.lower() in ('electron', 'electrons', 'e', 'e-'):
-                        phdr = detdata.primaryheader()
-                        time = phdr['EXPTIME']
-                        sci /= time
-                        unc /= time
-
-                    # initialize a good-pixel mask as the pixels that are finite
-                    gpx = np.isfinite(sci) & np.isfinite(unc)
-
-                    # update the good-pixel mask with a bitmask
-                    if detdata.config.bitmask:
-                        gpx &= (np.bitwise_and(dqa, detdata.config.bitmask) == 0)
-
-                    # if detdata.config.bitmask:
-                    #    gpx = np.bitwise_and(dqa, detdata.config.bitmask) == 0
-                    # else:
-                    #    gpx = np.ones_like(dqa, dtype=bool)
-
-                    # this will work, but maybe less efficient?
-                    # bad = np.logical_not(np.isfinite(sci) & np.isfinite(unc))
-                    # gpx[bad] = False
-
-                    # update the mask for the mask orders
-                    for ordname in self.mskorders:
-                        h5.load_order(ordname)
-                        for source in sources.values():
-                            omt = h5.load_omt(source)
-                            gpx[omt.get('y'), omt.get('x')] = False
-
                     # load all the submatrices for each order
-                    Aimg, yx = self.load_image_matrix(h5, detdata, sources, gpx)
+                    Aimg = self.load_image_matrix(h5, detdata, sources)
+                    if Aimg.nnz > 0:
 
-                    # grab the pixel values from data and uncertainty
-                    # but NB: the unc could potentially be zero, which will
-                    # cause problems with weighting by inverse-variance.
-                    # so the value minunc will set the minimum uncertainty
-                    # to avoid this problem
-                    s = sci[yx]
-                    u = np.maximum(unc[yx], self.minunc)
+                        # read the images
+                        sci, hdr = detdata.readfits('science', header=True)
+                        unc = detdata.readfits('uncertainty')
+                        dqa = detdata.readfits('dataquality')
 
-                    # normalize the data and matrices by the uncertainties
-                    # for inverse-variance weighting of the solution (ie.
-                    # solving maximum likelihood).  But will change to a
-                    # column matrix for latter use
-                    Aimg /= u[:, np.newaxis]
-                    s /= u
+                        # adjust the units if necessary
+                        bunit = hdr.get('BUNIT', 'electron/s')
+                        if bunit.lower() in ('electron', 'electrons', 'e', 'e-'):
+                            phdr = detdata.primaryheader()
+                            time = phdr['EXPTIME']
+                            sci /= time
+                            unc /= time
 
-                    # save the data and matrices
-                    self.b.extend(s)
-                    self.A.append(Aimg.tocsc())
+                        # initialize a good-pixel mask as the pixels that
+                        # are finite
+                        gpx = np.isfinite(sci) & np.isfinite(unc)
+
+                        # update the good-pixel mask with a bitmask
+                        if detdata.config.bitmask:
+                            gpx &= (np.bitwise_and(dqa, detdata.config.bitmask) == 0)
+
+                        # update the mask for the mask orders
+                        for ordname in self.mskorders:
+                            h5.load_order(ordname)
+                            for source in sources.values():
+                                omt = h5.load_omt(source)
+                                gpx[omt.get('y'), omt.get('x')] = False
+
+                        # get the bad pixels
+                        ncol = np.diff(Aimg.indptr)
+                        yx = np.where(gpx.flatten() & (ncol > 0))[0]
+                        y, x = np.unravel_index(yx, shape=detdata.shape)
+
+                        # remove the bad data
+                        Aimg = Aimg[yx]
+                        s = sci[y, x]
+                        u = np.maximum(unc[y, x], self.minunc)
+
+                        # normalize the data and matrices by the uncertainties
+                        # for inverse-variance weighting of the solution (ie.
+                        # solving maximum likelihood).  But will change to a
+                        # column matrix for latter use
+                        Aimg /= u[:, np.newaxis]
+                        s /= u
+
+                        # save the data and matrices
+                        self.b.extend(s)
+                        self.A.append(Aimg.tocsc())
 
                     # save some light-weight things about this image
-                    imgdata = ImageData(datum.dataset, detname, yx)
+                    imgdata = ImageData(datum.dataset, detname, (y, x))
                     self.imgdata.append(imgdata)
 
         # store things in a way to use later

--- a/slitlessutils/core/modules/extract/multi/matrix.py
+++ b/slitlessutils/core/modules/extract/multi/matrix.py
@@ -16,6 +16,70 @@ ImageData = namedtuple("ImageData", ['dataset', 'detname', 'pixels'])
 
 
 class Matrix:
+    r"""
+    Builds a linear operator to implement the linear-reconstruction
+    as described in Ryan, Casertano, & Pirzkal (2018).
+
+    Here we describe the flux in a pixel in a spectroscopic image as a
+    weighted sum over all sources and all wavelengths.  Suppose there is a
+    collection of sources labeled as: :math:`{A, B, C, D, ...}`, each of
+    which has a collection of wavelenghts denoted as:
+    :math:`{1, 2, 3, 4, ...}`.  Now the spectral elements will be given
+    by: :math:`{F_{A,1}, F_{A,2}, F_{A,3}, ..., F_{B,1}, F_{B,2},
+    F_{B,3}, ...,  F_{C,1}, F_{C,2}, F_{C,3}, ...`.
+    Based on that, then the flux in a spectrsocopic image will be:
+
+    .. math::
+       f = w_{A,1}*F_{A,1} + w_{A,2}*F_{A,2} + w_{B,5}*F_{B,6} + w_{E, 8}*F_{E, 8} + ...
+
+    where :math:`f` is the observed flux in a pixel in the spectral image,
+    :math:`F_{A, 1}` is the spectrum of object :math:`A` at the first
+    wavelength of interest and similarly for object :math:`B`, :math:`E`,
+    and so on.  The weights :math:`w_{A,1}` (and so on for the other objects
+    and wavelengths) effectively act as unit conversions between the
+    incident spectra and the observed flux on the instrument, and can be
+    determined by a brute-force forward-model simulation.  Importantly, a
+    similar equation for each observed pixel can be established, which of
+    course will have different set of weights.  But with all the weights
+    determined, they can be formulated into a canonical matrix equation:
+
+    .. math::
+       \mathbf{b} = \mathbf{A}\mathbf{x}
+
+    where :math:`\mathbf{b}` is the "data vector" composed of the collection
+    of observed pixel-level data, :math:`\mathbf{A}` is the collection of
+    weights rearranged in a matrix format, and :math:`\mathbf{x}` is the
+    "unknown vector" composed of the spectra for each object.  Importantly,
+    many of the weighting factors will be identically zero, since only very
+    few sources at very select wavelengths will deposit flux on any given
+    pixel in any given observation.  Therefore the matrix :math:`A` will be
+    a very sparse matrix, and so internally, it is built and manipulated
+    as a `scipy.sparse.csr_matrix()` object.
+
+    This linear system can be solved in a chi2-sense using standard methods:
+    `scipy.sparse.linalg.lsqr()` and `scipy.sparse.linalg.lsmr()`, both of
+    which optimize the regularized penalty function:
+
+    .. math::
+       \chi^2 = ||\mathbf{A}\mathbf{x} - \mathbf{b}||^2 + \ell||\mathbf{x}||^2
+
+    where :math:`\ell` is the Tikhonov regularization parameter.  There
+    have been several techniques for proposed for optimizing this value, see:
+
+    - https://epubs.siam.org/doi/book/10.1137/1.9780898719697
+    - https://ui.adsabs.harvard.edu/abs/2020IOPSN...1b5004C/abstract
+    - https://ui.adsabs.harvard.edu/abs/2018PASP..130c4501R/
+    - https://ui.adsabs.harvard.edu/abs/2024A%26A...684A..21N/abstract
+    - https://ui.adsabs.harvard.edu/abs/2026arXiv260105233A/abstract
+
+    However, slitlessutils follows the prescription of Ryan, Casertano,
+    & Pirzkal (2018), which maximizes the curvature in the L-curve
+    based on Hansen (1998) including the golden-search methods of Cultrera
+    & Callegaro (2020).
+
+    """
+
+    _VALID_BUNITS = ('electron', 'electrons', 'e', 'e-')
 
     def __init__(self, extorders, **kwargs):
         # extract the defaults
@@ -41,13 +105,13 @@ class Matrix:
     def __str__(self):
         return f'Sparse matrix with {len(self)} elements'
 
-    def load_image_matrix(self, h5, detdata, sources, removezeros=False):
+    def load_image_matrix(self, h5_file, detdata, sources, removezeros=False):
         '''
         Load a CSR matrix for a given WFSS image
 
         Inputs
         ------
-        h5 : h5py file object
+        h5_file : h5py file object
             The file to load the table from
 
         detdata : `WFSSDetector`
@@ -73,9 +137,9 @@ class Matrix:
         flatfield = detdata.config.load_flatfield()
 
         # a container to hold all the submatrices
-        A = []
+        A_image = []
         for ordname in self.extorders:
-            h5.load_order(ordname)
+            h5_file.load_order(ordname)
             sensitivity = detdata.config[ordname].sensitivity
 
             for source in sources.values():
@@ -94,7 +158,7 @@ class Matrix:
                 shape = (npix, nlam)
 
                 for regidx, region in enumerate(source):
-                    tab = h5.load_odt(region)
+                    tab = h5_file.load_odt(region)
                     if tab:
                         wav = tab.wavelengths()
                         x = tab.get('x', dtype=int)
@@ -114,30 +178,30 @@ class Matrix:
                         aij = (val * sens * flat * area)
 
                         # make the local sparse matrix
-                        Asub = sparse.csr_matrix((aij, (i, j)), shape=shape)
+                        A_region = sparse.csr_matrix((aij, (i, j)), shape=shape)
 
                     else:
                         # create an empty matrix for objects out of the field
-                        Asub = sparse.csr_matrix(shape)
+                        A_region = sparse.csr_matrix(shape)
 
                     # save it to the list, so we can stack them later
-                    A.append(Asub)
+                    A_image.append(A_region)
 
         # stack all the sparse matrices
-        A = sparse.hstack(A)
+        A_image = sparse.hstack(A_image)
 
         if removezeros:
             # find the rows that are all zero
-            yx = np.where(np.diff(A.indptr))[0]
+            yx = np.where(np.diff(A_image.indptr))[0]
 
             # remove the zero rows
-            A = A[yx]
+            A_image = A_image[yx]
 
             # get the image coordinates
             y, x = np.unravel_index(yx, shape=detdata.shape)
-            return A, (y, x)
+            return A_image, (y, x)
         else:
-            return A
+            return A_image
 
     def build_matrix(self, data, sources, group=0):
         '''
@@ -193,14 +257,14 @@ class Matrix:
                           dynamic_ncols=True):
 
             # load the data for this WFSS image
-            with PDTFile(datum, path=self.path, mode='r') as h5:
+            with PDTFile(datum, path=self.path, mode='r') as h5_file:
 
                 for detindex, (detname, detdata) in enumerate(datum.items()):
-                    h5.load_detector(detname)
+                    h5_file.load_detector(detname)
 
                     # load all the submatrices for each order
-                    Aimg = self.load_image_matrix(h5, detdata, sources)
-                    if Aimg.nnz > 0:
+                    A_image = self.load_image_matrix(h5_file, detdata, sources)
+                    if A_image.nnz > 0:
 
                         # read the images
                         sci, hdr = detdata.readfits('science', header=True)
@@ -209,7 +273,7 @@ class Matrix:
 
                         # adjust the units if necessary
                         bunit = hdr.get('BUNIT', 'electron/s')
-                        if bunit.lower() in ('electron', 'electrons', 'e', 'e-'):
+                        if bunit.lower() in self._VALID_BUNITS:
                             phdr = detdata.primaryheader()
                             time = phdr['EXPTIME']
                             sci /= time
@@ -225,18 +289,18 @@ class Matrix:
 
                         # update the mask for the mask orders
                         for ordname in self.mskorders:
-                            h5.load_order(ordname)
+                            h5_file.load_order(ordname)
                             for source in sources.values():
-                                omt = h5.load_omt(source)
+                                omt = h5_file.load_omt(source)
                                 gpx[omt.get('y'), omt.get('x')] = False
 
                         # get the bad pixels
-                        ncol = np.diff(Aimg.indptr)
+                        ncol = np.diff(A_image.indptr)
                         yx = np.where(gpx.flatten() & (ncol > 0))[0]
                         y, x = np.unravel_index(yx, shape=detdata.shape)
 
                         # remove the bad data
-                        Aimg = Aimg[yx]
+                        A_image = A_image[yx]
                         s = sci[y, x]
                         u = np.maximum(unc[y, x], self.minunc)
 
@@ -244,12 +308,12 @@ class Matrix:
                         # for inverse-variance weighting of the solution (ie.
                         # solving maximum likelihood).  But will change to a
                         # column matrix for latter use
-                        Aimg /= u[:, np.newaxis]
+                        A_image /= u[:, np.newaxis]
                         s /= u
 
                         # save the data and matrices
                         self.b.extend(s)
-                        self.A.append(Aimg.tocsc())
+                        self.A.append(A_image.tocsc())
 
                     # save some light-weight things about this image
                     imgdata = ImageData(datum.dataset, detname, (y, x))

--- a/slitlessutils/core/modules/extract/multi/matrix.py
+++ b/slitlessutils/core/modules/extract/multi/matrix.py
@@ -22,7 +22,7 @@ class Matrix:
     Here we describe the flux in a pixel in a spectroscopic image as a
     weighted sum over all sources and all wavelengths.  Suppose there is a
     collection of sources labeled as: :math:`{A, B, C, D, ...}`, each of
-    which has a collection of wavelenghts denoted as:
+    which has a collection of wavelengths denoted as:
     :math:`{1, 2, 3, 4, ...}`.  Now the spectral elements will be given
     by: :math:`{F_{A,1}, F_{A,2}, F_{A,3}, ..., F_{B,1}, F_{B,2},
     F_{B,3}, ...,  F_{C,1}, F_{C,2}, F_{C,3}, ...`.

--- a/slitlessutils/core/modules/extract/multi/matrix.py
+++ b/slitlessutils/core/modules/extract/multi/matrix.py
@@ -11,7 +11,6 @@ from ....utilities import as_iterable, headers  # , indices
 from .lcurve import LCurve
 from .result import Result
 
-
 ImageData = namedtuple("ImageData", ['dataset', 'detname', 'pixels'])
 
 
@@ -144,7 +143,7 @@ class Matrix:
 
             for source in sources.values():
 
-                # get the extration properties for this source
+                # get the extraction properties for this source
                 if hasattr(source, 'extpars'):
                     extpars = source.extpars
                 else:
@@ -554,7 +553,7 @@ class Matrix:
 
     # --------------------------------------------------------------------
     #
-    #                      some properites
+    #                      some properties
     #
     # --------------------------------------------------------------------
 

--- a/slitlessutils/core/modules/extract/multi/multi.py
+++ b/slitlessutils/core/modules/extract/multi/multi.py
@@ -1,13 +1,13 @@
 import getpass
 
+import numpy as np
 from astropy.io import fits
 from matplotlib.backends.backend_pdf import PdfPages
-import numpy as np
 from tqdm import tqdm
 
 from .....config import SUFFIXES, Config
 from .....logger import LOGGER
-from ....utilities import as_iterable, get_metadata, headers, compression
+from ....utilities import as_iterable, compression, get_metadata, headers
 from ...group import GroupCollection
 from ...module import Module
 from .matrix import Matrix
@@ -176,7 +176,7 @@ class Multi(Module):
 
                     # do each source
                     for segid, source in grpsources.items():
-                        # get the extration properties for this source
+                        # get the extraction properties for this source
                         if hasattr(source, 'extpars'):
                             wave = source.extpars.wavelengths()
                         else:
@@ -246,7 +246,7 @@ class Multi(Module):
                     for y, x, m in models[key]:
                         mod[y, x] += m * unc[y, x]
 
-                    # udpate the header info
+                    # update the header info
                     hdr['EXTNAME'] = 'MOD'
 
                     # save to the output

--- a/slitlessutils/core/modules/extract/multi/multi.py
+++ b/slitlessutils/core/modules/extract/multi/multi.py
@@ -1,12 +1,13 @@
 import getpass
 
-import numpy as np
 from astropy.io import fits
 from matplotlib.backends.backend_pdf import PdfPages
+import numpy as np
+from tqdm import tqdm
 
 from .....config import SUFFIXES, Config
 from .....logger import LOGGER
-from ....utilities import as_iterable, get_metadata, headers
+from ....utilities import as_iterable, get_metadata, headers, compression
 from ...group import GroupCollection
 from ...module import Module
 from .matrix import Matrix
@@ -75,7 +76,7 @@ class Multi(Module):
         self.optimizer = optimizer(algorithm, logdamp)
         self.matrix = Matrix(self.extorders, **kwargs)
 
-    def extract(self, data, sources, groups=None):
+    def extract(self, data, sources, groups=None, computemodel=True, gzip=True):
         """
         Method to do the mult-ended spectral extraction
 
@@ -90,6 +91,12 @@ class Multi(Module):
         groups : `GroupCollection` or None
             The collection of groups.  If set as None, then no grouping
             will be performed.  Default is None
+
+        computemodel : bool
+            Flag to compute the model spectral image.  Default is True
+
+        gzip : bool
+            Flag to gzip model images.  Default is True
 
         Notes
         -----
@@ -113,6 +120,8 @@ class Multi(Module):
         sources.update_header(phdu.header)                 # about the sources
         self.optimizer.update_header(phdu.header)
         Config().update_header(phdu.header)                # global config info
+        if groups is not None:
+            groups.update_header(phdu.header)
 
         # add the primary to the file
         hdul1.append(phdu)
@@ -129,6 +138,9 @@ class Multi(Module):
             LOGGER.info('No grouping')
             groups = GroupCollection()
 
+        # container to hold the model values
+        models = {}
+
         # open a PDF to write Grouping images
         pdffile = f'{self.root}_{SUFFIXES["L-curve"]}.pdf'
         LOGGER.info(f'Writing grouped L-curve figure: {pdffile}')
@@ -141,49 +153,124 @@ class Multi(Module):
             d['Keywords'] = f'{package} WFSS L-curve groups'
             d['Producer'] = package
 
-            for grpid, srcdict in enumerate(groups(sources)):
+            # keep a list of segids that have not had their spectrum measured.
+            # so to start, no objects have been measured, so initialize to
+            # the full list of segids
+            segids = list(sources.keys())
 
-                self.matrix.build_matrix(data, srcdict)
+            # process each group
+            for grpid, grpsources in enumerate(groups.groups(sources)):
 
-                res = self.optimizer(self.matrix)
-                unc = self.matrix.compute_uncertainty()
+                # build a matrix for these sources
+                self.matrix.build_matrix(data, grpsources, group=grpid)
 
-                for sid, lid in self.matrix.ri.items():
-                    segid, regid = self.matrix.sedkeys[sid]
-                    lamid = self.matrix.lamids[lid]
+                # only continue if the matrix is valid
+                if self.matrix:
 
-                    if hasattr(sources[segid], 'extpars'):
-                        pars = sources[segid].extpars
-                    else:
-                        pars = self.matrix.defpars
+                    # solve the system
+                    res = self.optimizer(self.matrix)
+                    unc = self.matrix.compute_uncertainty()
 
-                    # variables for outputting
-                    wave = pars.wavelengths()
-                    flam = np.full_like(wave, np.nan, dtype=float)
-                    func = np.full_like(wave, np.nan, dtype=float)
+                    # initialize a counter
+                    s = slice(0, 0)
 
-                    # nota bene:  the methods LSQR and LSMR will formally
-                    # return the uncertainties, but are the diagonal
-                    # elements of (A'A + ell *I)^-1, which will be
-                    # incorrect if ell != 0 (see Ryan Casertano Pirzkal 2018)
-                    # Therefore, we also estimate the diagonal elements of
-                    # A'A, and invert them.  This is not correct, but a
-                    # different error than including the damping.
+                    # do each source
+                    for segid, source in grpsources.items():
+                        # get the extration properties for this source
+                        if hasattr(source, 'extpars'):
+                            wave = source.extpars.wavelengths()
+                        else:
+                            wave = self.matrix.defpars.wavelengths()
+                        nwave = len(wave)
 
-                    # populate the results
-                    flam[lamid] = res.x[lid]
-                    func[lamid] = unc[lid]      # from matrix elements
-                    # func[lamid]=res.lo[lid]   # from matrix inversion (wrong!)
+                        segids.remove(segid)
 
-                    # update the outputting structures
-                    sources[segid].grpid = grpid
-                    # sources[segid].spectralregions[regid].sed.reset(wave,flam,
-                    sources[segid][regid].sed.reset(wave, flam, func=func)
+                        # do each spectral region
+                        for regid, region in enumerate(source):
+                            s = slice(s.stop, s.stop + nwave)
+
+                            # get the fluxes from the objects
+                            flam = res.x[s]
+                            func = unc[s]
+
+                            # if something has unc == 0, then it's bad
+                            uncons = self.matrix.unconstrained[s]
+                            flam[uncons] = np.nan
+                            func[uncons] = np.nan
+
+                            # update the outputting structures
+                            sources[segid].grpid = grpid
+                            sources[segid][regid].sed.reset(wave, flam,
+                                                            func=func)
+
+                    # compute the model values
+                    if computemodel:
+                        model = self.matrix.compute_model(res.x)
+
+                        for key, mod in model.items():
+                            if key not in models:
+                                models[key] = []
+                            models[key].extend(mod)
 
                 # update results for the L-curve data
-                kwargs = {'nobj': (len(srcdict), 'Number of sources')}
+                kwargs = {'nobj': (len(grpsources), 'Number of sources')}
                 hdulL.append(self.matrix.lcurve.as_HDU(grpid=grpid, **kwargs))
-                self.matrix.lcurve.pdfplot(pdf)
+                self.matrix.lcurve.pdfplot(pdf, grpid=grpid)
+
+        if computemodel:
+            # issue a logging message
+            LOGGER.info("Making model images")
+
+            # now let's compute the residuals from the linear model
+            for datum in tqdm(data, desc='Rendering models', total=len(data),
+                              dynamic_ncols=True):
+
+                # get the output image
+                modfile = f'{datum.dataset}_mod.fits'
+
+                # for output file
+                hdul = fits.HDUList()
+                hdul.append(fits.PrimaryHDU(header=datum.primaryheader()))
+
+                # process each extension
+                for detname, detdata in datum.items():
+                    # get some info
+                    hdr = detdata.headfits('science')
+                    unc = detdata.readfits('uncertainty')
+                    mod = np.zeros_like(unc, dtype=float)
+
+                    # sum over the model, but recall we need the uncertainty
+                    # to undo the inverse-variance weighting ineherent in
+                    # the matrix inversion algorithm (see Ryan+ 2018, PASP)
+                    key = (datum.dataset, detname)
+                    for y, x, m in models[key]:
+                        mod[y, x] += m * unc[y, x]
+
+                    # udpate the header info
+                    hdr['EXTNAME'] = 'MOD'
+
+                    # save to the output
+                    hdul.append(fits.ImageHDU(data=mod, header=hdr))
+
+                # write the file to disk
+                hdul.writeto(modfile, overwrite=True)
+
+                # gzip the file if asked
+                if gzip:
+                    compression.compress(modfile)
+
+        # remove the sources for which we didn't measure a spectrum
+        for segid in segids:
+            if hasattr(source, 'extpars'):
+                wave = source.extpars.wavelengths()
+            else:
+                wave = self.matrix.defpars.wavelengths()
+
+            nans = np.full_like(wave, np.nan)
+
+            # update the outputting structures
+            sources[segid].grpid = -1
+            sources[segid][regid].sed.reset(wave, nans, func=nans)
 
         # loop over sources for outputting
         for source in sources.values():
@@ -193,57 +280,6 @@ class Multi(Module):
                 hdul3.append(hdu)
             else:
                 hdul1.append(hdu)
-
-
-#        self.matrix.build_matrix(data,sources)
-#
-#        res=self.optimizer(self.matrix)
-#
-#
-#        # loop over elements
-#        for sid,lid in self.matrix.ri.items():
-#            segid,regid=self.matrix.sedkeys[sid]
-#            lamid=self.matrix.lamids[lid]
-#
-#            if hasattr(sources[segid],'extpars'):
-#                pars=sources[segid].extpars
-#            else:
-#                pars=self.matrix.defpars
-#
-#            # variables for outputting
-#            wave=pars.wavelengths()
-#            flam=np.full_like(wave,np.nan,dtype=float)
-#            func=np.full_like(wave,np.nan,dtype=float)
-#
-#
-#            # populate the results
-#            flam[lamid]=res.x[lid]
-#            func[lamid]=res.lo[lid]
-#
-#            # update the outputting structures
-#            sources[segid].spectralregions[regid].sed.reset(wave,flam,func=func#)
-#
-#            # output ascii spectrum
-#            #with open(f'multi_{segid}_{regid}.csv','w') as fp:
-#            #    print('wavelength,flam,func',file=fp)
-#            #    for w,f,df in zip(wave,flam,func):
-#            #'        print(f'{w},{f},{df}',file=fp)
-#
-#
-#
-#        # loop over sources for outputting
-#        for source in sources.values():
-#
-#            hdu=source.as_HDU()
-#            if source.is_compound:
-#                hdul3.append(hdu)
-#            else:
-#                hdul1.append(hdu)
-#
-#
-#
-#
-#        self.matrix.lcurve.plot(f'{self.root}_{SUFFIXES["L-curve"]}.pdf')
 
         # write out the files
         if len(hdul1) > 1:

--- a/slitlessutils/core/modules/extract/single/boxcar.py
+++ b/slitlessutils/core/modules/extract/single/boxcar.py
@@ -7,7 +7,7 @@ from ....utilities import indices
 from .spectraltable import SpectralTable
 
 
-def boxcar(source, det, sci, unc, dqa, flatfield, order, odt,
+def boxcar(source, det, sci, unc, dqa, flatfield, order, odt, chdu,
            width=17, summation='cartesian', plot=False):
     '''
     Worker function to perform boxcar or "aperture" spectroscopy
@@ -37,6 +37,9 @@ def boxcar(source, det, sci, unc, dqa, flatfield, order, odt,
 
     odt : `slitlessutils.core.tables.ODT`
        The object-dispersion table (ODT).
+
+    chdu : `fits.ImageHDU()`
+       The contamination data
 
     width : int or float
        The extraction width in pixels.  Default is 15 pix
@@ -120,24 +123,39 @@ def boxcar(source, det, sci, unc, dqa, flatfield, order, odt,
             calib = flat * area * sens * disp
 
             # apply the calibrations
-            maxcal = np.amax(calib)
-            if maxcal > 1e-15:
+            g = np.where(calib > 0)[0]
+            if len(g) > 0:
+                # use only the valid data
+                xs = xs[g]
+                ys = ys[g]
+                calib = calib[g]
+                aper = aper[g]
+
                 # the calibrated images
                 calsci = (sci[ys, xs] / calib)
                 calvar = (unc[ys, xs] / calib)**2
 
+                # compute the contamination, but recall, we store the
+                # contamination image in a cut out.... So have to get the
+                # apply that offset from the LTV1/2 keywords
+                xc = xs + chdu.header['LTV1']
+                yc = ys + chdu.header['LTV2']
+                calcnt = chdu.data[yc, xc]
+
                 # sum the data with calibrations applied
                 flam = np.sum(calsci * aper)
+                cont = np.sum(calcnt * aper)
                 fvar = np.sum(calvar * aper)
             else:
                 flam = np.inf
                 fvar = np.inf
+                cont = 0.0
 
             # sum the data
             flux = np.nansum(sci[ys, xs] * aper)
 
             # save the results
-            spec.append(wave, disp, flam, np.sqrt(fvar), flux, 0.0, npix)
+            spec.append(wave, disp, flam, np.sqrt(fvar), flux, cont, npix)
 
         # make a diagnostic plot?
         if plot:

--- a/slitlessutils/core/modules/extract/single/single.py
+++ b/slitlessutils/core/modules/extract/single/single.py
@@ -415,8 +415,7 @@ class Single(Module):
 
                                 # get the contam data
                                 chdu = self.contamination(segid, ordname,
-                                                          h5, sources,
-                                                          detdata, flatfield,
+                                                          h5, sources, detdata, flatfield,
                                                           bbx=(x0, x1), bby=(y0, y1))
 
                                 if self.savecont:
@@ -425,10 +424,13 @@ class Single(Module):
                                 # get the offsets in the contamination image
                                 # xoff = -chdu.header.get('LTV1', 0)
                                 # yoff = -chdu.header.get('LTV2', 0)
+                            else:
+                                chdu = fits.ImageHDU()
 
                             if extmode == 'boxcar':
-                                spectrum = boxcar(source, detdata, sci, unc, dqa, flatfield, order,
-                                                  odt, width=width)
+                                spectrum = boxcar(source, detdata, sci, unc,
+                                                  dqa, flatfield, order, odt, chdu,
+                                                  width=width)
 
                                 spectra[segid] += spectrum
 

--- a/slitlessutils/core/modules/group/group.py
+++ b/slitlessutils/core/modules/group/group.py
@@ -1,8 +1,15 @@
-from shapely import geometry
+from collections import namedtuple
+
+import networkx
+import numpy as np
+from shapely import Polygon
 
 from ...tables import PDTFile
 from ..module import Module
 from .groupcollection import GroupCollection
+
+
+Key = namedtuple('Key', ['filename', 'detname', 'ordname', 'segid'])
 
 
 class Group(Module):
@@ -30,210 +37,69 @@ class Group(Module):
 
     DESCRIPTION = "Grouping WFSS"
 
-    def __init__(self, minarea=0.1, orders=None, **kwargs):
-        Module.__init__(self, self.group_wfss, postfunc=self.group_return,
+    def __init__(self, threshold=0.01, orders=None, **kwargs):
+
+        Module.__init__(self, self.group_oneimage, postfunc=self.group_images,
                         **kwargs)
 
-        self.minarea = minarea
+        self.threshold = np.clip(threshold, 0, 1)
         self.orders = orders
 
-    def group_wfss(self, data, sources, **kwargs):
-        """
-        Method to group the WFSS images
+    def group_oneimage(self, data, sources, **kwargs):
 
+        group = GroupCollection(threshold=self.threshold,
+                                orders=self.orders)
 
-        Parameters
-        ----------
-        data : `WFSSCollection`
-           The WFSS data to group
-
-        sources : `SourceCollection`
-           The sources to group
-
-        kwargs : dict, optional
-           Dictionary of optional keywords.  Not currently used.
-
-        Returns
-        -------
-        segids : list
-           A list of sets, where each element of the list is a given
-           group.  Therefore, this list has 1<=len(segids)<=len(sources).
-
-
-        Notes
-        -----
-        This is the main routine, but is unlikely to be directly called
-
-        """
-
-        # conf,wfss=data
+        # read all sources as Shapely polygons
+        polys = []
         with PDTFile(data, path=self.path, mode='r') as h5:
-            groups = []
             for detname, detconf in data.items():
                 h5.load_detector(detname)
 
-                # the collection of Shapely Polygons and segids
-                polys = []
-                ids = []
-                for i, (segid, source) in enumerate(sources.items()):
-                    poly = []
+                for ordname in self.orders:
+                    h5.load_order(ordname)
 
-                    # read each order as a Shapely Polygon
-                    for ordname in self.orders:
-                        h5.load_order(ordname)
+                    for segid, source in sources.items():
                         odt = h5.load_odt(source)
-                        poly.append(odt.shapelyPolygon())
+                        if odt:
 
-                    # glue the individual orders together as a MultiPolygon
-                    poly = geometry.MultiPolygon(poly)
+                            # load the vertices
+                            x0, x1, y0, y1 = odt.bounding_box()
+                            vertices = ((x0, y0), (x0, y1), (x1, y1),
+                                        (x1, y0), (x0, y0))
 
-                    # aggregate all the MultiPolygons and orders
-                    polys.append(poly)
-                    ids.append([source.segid])
+                            # store some data for this trace
+                            key = Key(data.filename, detname, ordname, segid)
+                            poly = Polygon(vertices)
 
-                # package the ids and polygons
-                data = list(zip(ids, polys))
+                            # save the trace data
+                            polys.append((key, poly))
 
-                # group all of the sources' polygons using Shapely math
-                grouped = self.group_polygons(data)
+        # add vertices for each source
+        for segid, source in sources.items():
+            group.add_object(segid, source.mag)
 
-                # collect the grouped polygons
-                groups.append(grouped)
+        # now test all n^2 operations.  But we can ignore the lower triangle
+        n = len(polys)
+        for i in range(n):
+            keyi, polyi = polys[i]
 
-        # at this point, we no longer need the shapely polygons. and instead
-        # will just work with SEGIDs as sets, and use set math (is faster)
-        segids = list(list(zip(*groups[0]))[0])
-        segids = [set(i) for i in segids]
-        segids = self.group_ids(segids)
+            for j in range(i + 1, n):
+                keyj, polyj = polys[j]
 
-        return segids
+                inter = polyi.intersection(polyj)
+                if inter:
+                    union = polyi.union(polyj)
 
-    def group_polygons(self, data):
-        """
-        Helper function to group sources based on shapely math
+                    ratio = inter.area / union.area
+                    if ratio > self.threshold:
+                        group.add_contamination(keyi.segid, keyj.segid, ratio)
 
-        Parameters
-        ----------
-        data : list
-           A list of 2-tuples to group.  The elements of the tuple are given
-           as the segmentation ID and a `shapely.geometry.Polygon` object
-           respectively.
+        return group
 
-        Returns
-        -------
-        new : list
-           A list of 2-tuples that have been grouped.  The output tuples
-           have the same meaning as the input
-
-        """
-        nnew = ndata = len(data)
-
-        # process until there is nothing left to process
-        while nnew:
-            groups = []
-
-            while data:
-
-                # grab the first polygon and ID
-                thisid, thispoly = data.pop(0)
-
-                # iterate over all other polygons and IDs
-                for i, (testid, testpoly) in enumerate(data):
-                    inter = thispoly.intersection(testpoly)
-
-                    # is the intersection a positive region?
-                    if (inter.area > self.minarea * testpoly.area) and \
-                       (inter.area > self.minarea * thispoly.area):
-
-                        # remove the test polygon, glue the test polygon and
-                        # segIDs to the primary polygon and list
-                        data.pop(i)
-                        thispoly = thispoly.union(testpoly)
-                        thisid.extend(testid)
-
-                # collect this result
-                groups.append((thisid, thispoly))
-
-            # iterate until we've cycled thru everything
-            N = len(data)
-            data = groups
-            nnew = ndata - N
-            ndata = N
-        return data
-
-    def group_ids(self, data):
-        """
-        Helper method to group segmentation IDs using set-logic
-
-        Parameters
-        ----------
-        data : list
-            A list of sets.  Each element of the list represents a putative
-            group, while each element of any set represents the segmentation
-            ID of a source that has been grouped.
-
-        Returns
-        -------
-        new : list
-            A list of sets, with the same interpretation as the input list.
-        """
-
-        nnew = ndata = len(data)
-
-        while nnew:
-            new = []
-            while data:
-                this = data.pop(0)
-                for i, test in enumerate(data):
-                    if this.intersection(test):
-                        this = this.union(test)
-                        data.pop(i)
-                new.append(this)
-            data = new
-            n = len(data)
-            nnew = ndata - n
-            ndata = n
-        return data
-
-    def group_return(self, ids, data, sources, **kwargs):
-        """
-        Helper method to package the results into a `GroupCollection`
-
-        Parameters
-        ----------
-        ids : list
-            The list of sets from `self.group_ids()`
-
-        data : `WFSSCollection`
-            The WFSS data that was used to group
-
-        sources : `SourceCollection`
-            The sources to group
-
-        kwargs : dict, optional
-            Not used, but is a place holder for optional parameters
-
-        Returns
-        -------
-        out : `GroupCollection`
-           A collection of groups
-
-        """
-
-        sets = []
-        for i in ids:
-            sets.extend(i)
-
-        # group the IDs and sort by size
-        groups = self.group_ids(sets)
-        groups.sort(key=len, reverse=True)
-
-        # sort out what is the output product going to look like
-        out = GroupCollection(minarea=self.minarea, orders=self.orders)
+    def group_images(self, groups, data, sources, **kwargs):
+        group = GroupCollection()
         for grp in groups:
-            out.append(grp)
+            group.graph = networkx.compose(group.graph, grp.graph)
 
-        # out={k:list(v) for k,v in enumerate(groups)}
-        # out=[list(g) for g in groups]
-
-        return out
+        return group

--- a/slitlessutils/core/modules/group/group.py
+++ b/slitlessutils/core/modules/group/group.py
@@ -8,7 +8,6 @@ from ...tables import PDTFile
 from ..module import Module
 from .groupcollection import GroupCollection
 
-
 Key = namedtuple('Key', ['filename', 'detname', 'ordname', 'segid'])
 
 

--- a/slitlessutils/core/modules/group/groupcollection.py
+++ b/slitlessutils/core/modules/group/groupcollection.py
@@ -156,7 +156,8 @@ class GroupCollection:
 
         # draw and label the nodes
         nodes = nwx.draw_networkx_nodes(graph, pos, vmin=mag0,
-                                        vmax=mag1, node_color=mag, cmap=plt.cm.coolwarm,
+                                        vmax=mag1, node_color=mag,
+                                        cmap=plt.cm.coolwarm,
                                         node_size=200, ax=gax)
         nwx.draw_networkx_labels(graph, pos, font_size=10, ax=gax)
 
@@ -213,6 +214,28 @@ class GroupCollection:
             for segids in sorted(comps, key=len, reverse=True):
                 dct = {segid: sources[segid] for segid in segids}
                 yield dct
+
+    def __add__(self, other):
+        '''
+        Method to merge two GroupCollections
+
+        Inputs
+        ------
+        other : `GroupCollection()`
+            The other group to merge
+
+        Returns
+        -------
+        group : `GroupCollection()`
+            A new GroupCollection that is the merger of the two
+        '''
+
+        if isinstance(other, GroupCollection):
+            new = GroupCollection()
+            new.graph = nwx.compose(self.graph, other.graph)
+            return new
+        else:
+            raise NotImplementedError("Unable to add two GroupCollections")
 
 
 if __name__ == '__main__':

--- a/slitlessutils/core/modules/group/groupcollection.py
+++ b/slitlessutils/core/modules/group/groupcollection.py
@@ -215,6 +215,9 @@ class GroupCollection:
                 dct = {segid: sources[segid] for segid in segids}
                 yield dct
 
+    def __len__(self):
+        return nwx.number_connected_components(self.graph)
+
     def __add__(self, other):
         '''
         Method to merge two GroupCollections

--- a/slitlessutils/core/modules/group/groupcollection.py
+++ b/slitlessutils/core/modules/group/groupcollection.py
@@ -1,100 +1,241 @@
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+import networkx as nwx
+
+from ....logger import LOGGER
 from ...utilities import headers
 
 
-class GroupCollection(list):
+class GroupCollection:
     """
-    Class to collect the groups, which are sets of sources whose spectral
-    traces overlap in a given set of WFSS images
+    Use NetworkX to create graphs of spectral traces to assess
+    contamination.  Objects are represented by nodes in the graph
+    while contamination is represented by an edge, whose weight
+    is specified when defining a contaminant
 
-    inherits from `list`
+    Inputs
+    ------
+    threshold : float
+        Threshold to flag contamination (not used, just for safe keeping)
 
-    Parameters
-    ----------
-    order : list or None
-       The spectral orders to tabulate.  If `None`, then will do all orders
-       present in the configuration file.  Default is None
-
-    minarea : float, optional
-        The minimum fractional area to test for overlaps, see also
-        `su.core.modules.group.Group`  Default is 0.1
-
+    orders : str
+        The orders used for contamination (not used, just for safe keeping)
 
     """
 
-    def __init__(self, orders=None, minarea=0.1):
-        self.minarea = minarea
+    def __init__(self, threshold=0.0, orders=''):
+
+        # a basic graph to do the juggling
+        self.graph = nwx.Graph()
+
+        self.threshold = threshold
         self.orders = orders
 
-    def __str__(self):
-        if self:
-            s = "Extraction Groups:\n" + '\n'.join('  ' + str(g) for g in self)
+    def add_object(self, segid, mag):
+        """
+        Add a spectral trace to the graph.
+
+        Inputs
+        ------
+        segid : int, str, or tuple of int/str
+            The Object ID to consider.
+
+        mag : float
+            The magnitude.  This is used to set color of node in
+            graph.
+
+        """
+        # this is a basic node, but will add more attributes
+        self.graph.add_node(segid, magnitude=mag)
+
+    def add_contamination(self, segid0, segid1, weight):
+        """
+        Add a contamination entry
+
+        Inputs
+        ------
+        segid0 : int, str or tuple of int/str
+           The first object ID
+
+        segid1 : int, str or tuple of int/str
+           The second object ID
+
+        weight : float
+           The weight of the contamination.
+
+        """
+        # don't permit monitoring of self-contamination
+        if segid0 == segid1:
+            return
+
+        if self.graph.has_edge(segid0, segid1):
+            # if the edge exists, then update the weight
+            self.graph[segid0][segid1]['weight'] += weight
+
         else:
-            s = 'Extraction Groups (None)'
-        return s
+            # if the edge doesn't exist, then make a new one
+            self.graph.add_edge(segid0, segid1, weight=weight)
 
-    def __call__(self, sources):
-        if len(self) > 0:
-            for group in self:
-                yield {sources[g].segid: sources[g] for g in group}
+    def update_header(self, hdr, grouped=True):
+        """
+        Update a header for safe keeping
+
+        Inputs
+        ------
+        hdr : `astropy.io.fits.Header`
+           The header to update
+
+        grouped : bool
+           Flag if it was grouped (default is True)
+
+        """
+
+        hdr.set('GROUPED', value=grouped, comment='grouping flag')
+        hdr.set('GRPTHRSH', value=self.threshold,
+                comment='threshold for contamination')
+        hdr.set('GRPORDER', value=self.orders,
+                comment='orders for contamination')
+        headers.add_stanza(hdr, 'Grouping Properties', before='GROUPED')
+
+    def plot(self, filename=None, mag0=20, mag1=26, minobj=2):
+        """
+        Make a quick plot for diagnostics
+
+        Inputs
+        ------
+        filename : str, optional
+            A file name for output graphic.  Default is None
+
+        mag0 : float, optional
+            The minimum magnitude to assign to color mapping.
+            Default is 20
+
+        mag1 : float, optional
+            The maximum magnitude to assign to color mapping.
+            Default is 26
+
+        minobj : int, optional
+            The minimum number of nodes to show the subgraph.
+            Default is 2
+
+        """
+
+        LOGGER.info(f"Making group graphic: {filename}.")
+
+        # make copy for safekeeping
+        graph = self.graph.copy()
+
+        # remove distonnected subgraphs if they contain fewer than a
+        # minimum number of nodes
+        if minobj > 1:
+
+            # collect the segids to remove
+            badids = []
+            for comp in nwx.connected_components(graph):
+                if len(comp) < minobj:
+                    badids.extend(comp)
+
+            # remove them
+            graph.remove_nodes_from(badids)
+
+        # some plotting positions
+        b, r = 0.03, 0.95
+        w = (0.9, 0.02)
+        l = (0.01, w[0] + 0.01)
+
+        # make the plot window
+        fig = plt.figure(figsize=(10, 8))
+        gax = fig.add_axes((l[0], b, w[0], r))
+        cax = fig.add_axes((l[1], b, w[1], r))
+
+        # get positions for a given layout
+        pos = nwx.spring_layout(graph)
+
+        # Draw nodes with colormap
+        mag = [a['magnitude'] for a in graph.nodes.values() if a]
+
+        # draw and label the nodes
+        nodes = nwx.draw_networkx_nodes(graph, pos, vmin=mag0,
+                                        vmax=mag1, node_color=mag, cmap=plt.cm.coolwarm,
+                                        node_size=200, ax=gax)
+        nwx.draw_networkx_labels(graph, pos, font_size=10, ax=gax)
+
+        # draw the edges.  Will scale the weights by some value and
+        # introduce a minimum (don't want to have a weight that is
+        # too small), but this scalar likely needs adjusting
+        # based on how "weight" changes
+        weight = [min(5 * graph[u][v]['weight'], 1) for u, v in graph.edges()]
+        weight = [5 * graph[u][v]['weight'] for u, v in graph.edges()]
+        nwx.draw_networkx_edges(graph, pos, width=weight,
+                                ax=gax, edge_color='black')
+
+        # make a legend
+        weights = [1, 2, 3, 4, 5]
+        lines = [Line2D([0], [0], color='black', lw=w) for w in weights]
+        labels = [str(w / 5.) for w in weights]
+        gax.legend(lines, labels, title='fractional area', loc='upper left')
+
+        # dont draw the axes, since they have no meaning here
+        gax.axis('off')
+
+        # Add colorbar
+        cbar = fig.colorbar(nodes, cax=cax)
+        cbar.set_label("magnitude (mag)")
+
+        # save to a file
+        if isinstance(filename, str):
+            plt.savefig(filename)
         else:
-            yield sources
+            plt.show()
 
-    def append(self, grp):
+    def groups(self, sources):
         """
-        Method to include a new group
+        Iterator over the disconnected groups
 
-        Parameters
-        ----------
-        grp : list or scalar
-            The segmentation IDs for this group
-        """
-
-        super().append(tuple(grp))
-
-    @classmethod
-    def empty(cls):
-        """
-        Classmethod to create an empty `GroupCollection`.
-        """
-        return cls(minarea=None, orders=None)
-
-    def find_group(self, segid):
-        """
-        Method to find the group ID for a given segmentation ID
-
-        Parameters
-        ----------
-        segid : int
-            The segmentation ID to search for
+        Inputs
+        ------
+        sources : `SourceCollection`
+           The sources to sift through
 
         Returns
         -------
-        grpid : int
-            The group ID that contains the input segmentation ID.  If the
-            segmentation ID is not found, then returns None
+        grouped : dict
+           The segids
         """
+        n = len(self.graph)
 
-        for group, segids in enumerate(self):
-            if segid in segids:
-                return group
+        if n == 0:
+            yield sources
 
-    def update_header(self, hdr):
-        """
-        Method to update a fits header
+        else:
+            comps = nwx.connected_components(self.graph)
 
-        Parameters
-        ----------
-        hdr : `astropy.io.fits.Header`
-           The fits header to update
-        """
+            for segids in sorted(comps, key=len, reverse=True):
+                dct = {segid: sources[segid] for segid in segids}
+                yield dct
 
-        m = str(self.minarea) if self.minarea else 'N/A'
-        o = ','.join(self.orders) if self.orders else "N/A"
 
-        ngroup = max(len(self), 1)
-        # grouped=ngroup>1
-        # hdr['grouped']=(grouped,'Was this grouped?')
-        hdr['groups'] = (ngroup, 'Number of groups')
-        hdr['grparea'] = (m, 'Minimum fractional area for polygon intersection')
-        hdr['grpord'] = (o, 'Orders checked for grouping')
-        headers.add_stanza(hdr, 'Group Parameters', before='groups')
+if __name__ == '__main__':
+    import numpy as np
+
+    N = 100
+    mags = np.random.uniform(low=20, high=25., size=N)
+
+    groups = GroupCollection()
+
+    for i, m in enumerate(mags, start=1):
+        groups.add_object(i, m)
+
+    for i in range(N):
+
+        r = np.random.uniform()
+        if r > 0.7:
+            j = np.random.randint(low=1, high=N)
+            groups.add_contamination(i, j, np.random.uniform())
+
+            if np.random.uniform() > 0.2:
+                groups.add_contamination(j, i, np.random.uniform())
+
+    groups.add_object((1, 2), 23.)
+
+    groups.plot(filename='t.svg')

--- a/slitlessutils/core/modules/group/groupcollection.py
+++ b/slitlessutils/core/modules/group/groupcollection.py
@@ -1,6 +1,6 @@
 import matplotlib.pyplot as plt
-from matplotlib.lines import Line2D
 import networkx as nwx
+from matplotlib.lines import Line2D
 
 from ....logger import LOGGER
 from ...utilities import headers

--- a/slitlessutils/core/modules/simulate/simulate.py
+++ b/slitlessutils/core/modules/simulate/simulate.py
@@ -102,22 +102,6 @@ class Simulate(Module):
                 headers.add_stanza(phdu.header, 'POINTING INFORMATION',
                                    before='PA_V3')
 
-            # put the wavelengths in the header
-            # insconf.parameters.update_header(phdu.header)
-            # data.grating.update_header(phdu.header)
-            # data.disperser.update_header(phdu.header)
-
-            # put the orders in the header
-            # orders=self.orders if self.orders else data.orders
-            # phdu.header['NORDER']=(len(orders),'Number of orders in the image')
-            # phdu.header['ORDERS']=(','.join(orders),'Order names')
-            # headers.add_stanza(phdu.header,'Orders Information',
-            # before='NORDER')
-
-            # update for the reference SIAF Information
-            # data.siaf.update_header(phdu.header)
-            # insconf.refsiaf.update_header(phdu.header)
-
             # process each detector
             for detname, detdata in data.items():
                 # load a detector

--- a/slitlessutils/core/photometry/sed.py
+++ b/slitlessutils/core/photometry/sed.py
@@ -53,6 +53,11 @@ class SED:
              ('func', np.float32),
              ('cont', np.float32),
              ('npix', np.uint16)]
+
+    # names of externally visible keywords
+    EXTKEYS = {'lamb': 'WAVELENGTH', 'flam': "FLUX", 'func': 'UNCERTAINTY',
+               'cont': 'CONTAMINATION', 'npix': 'NMEASUREMENTS'}
+
     FORMAT = ('%.4e', '%.4e', '%.4e', '%.4e', '%6u')
     GROW = 2     # factor to resize a dynamic array
 
@@ -249,6 +254,29 @@ class SED:
         self._data['cont'][self.count:self.count + nadd] = cont
         self._data['npix'][self.count:self.count + nadd] = npix
         self.count += nadd
+
+    def for_output(self):
+        """
+        Method to rename the internal numpy columns for a more descriptive
+        output in the fits tables
+
+        Returns
+        -------
+        dat : `np.ndarray()`
+           This will be a structured numpy array with descriptive column names
+        """
+
+        # get the data locally
+        dat = self._data
+
+        # get the new names by remapping the internal names to better
+        # external names for the ouptut files
+        new_names = tuple(self.EXTKEYS[inkey] for inkey, dtype in self.DTYPE)
+
+        # reset the outputs
+        dat.dtype.names = new_names
+
+        return dat
 
     def __bool__(self):
         """

--- a/slitlessutils/core/photometry/sed.py
+++ b/slitlessutils/core/photometry/sed.py
@@ -788,7 +788,13 @@ class SED:
         cfg = Config()
         fluxunit = f'{cfg.fluxscale} {cfg.fluxunits}'
 
-        # update the output units
+        # update the output units in the header
+        hdu.header.set('TUNIT1', value='angstrom', after='TFORM1')
+        hdu.header.set('TUNIT2', value=fluxunits, after='TFORM2')
+        hdu.header.set('TUNIT3', value=fluxunits, after='TFORM3')
+        hdu.header.set('TUNIT4', value=fluxunits, after='TFORM4')
+        hdu.header.set('TUNIT5', value='number', after='TFORM5')
+        # update the output units on the data itself
         hdu.data.columns['WAVELENGTH'].unit = 'Angstrom'
         hdu.data.columns['FLUX'].unit = fluxunit
         hdu.data.columns['UNCERTAINTY'].unit = fluxunit

--- a/slitlessutils/core/photometry/sed.py
+++ b/slitlessutils/core/photometry/sed.py
@@ -120,7 +120,6 @@ class SED:
         """
         self._data = d
 
-    # def normalize(self,band,fnu):
     def normalize(self, wave, flux, abmag=False):
         """
         Method to renormalize the spectrum

--- a/slitlessutils/core/photometry/sed.py
+++ b/slitlessutils/core/photometry/sed.py
@@ -775,7 +775,7 @@ class SED:
         data = self.data
 
         # get the new names by remapping the internal names to better
-        # external names for the ouptut files
+        # external names for the output files
         new_names = tuple(self.EXTKEYS[inkey] for inkey, dtype in self.DTYPE)
 
         # reset the outputs

--- a/slitlessutils/core/photometry/sed.py
+++ b/slitlessutils/core/photometry/sed.py
@@ -255,29 +255,6 @@ class SED:
         self._data['npix'][self.count:self.count + nadd] = npix
         self.count += nadd
 
-    def for_output(self):
-        """
-        Method to rename the internal numpy columns for a more descriptive
-        output in the fits tables
-
-        Returns
-        -------
-        dat : `np.ndarray()`
-           This will be a structured numpy array with descriptive column names
-        """
-
-        # get the data locally
-        dat = self._data
-
-        # get the new names by remapping the internal names to better
-        # external names for the ouptut files
-        new_names = tuple(self.EXTKEYS[inkey] for inkey, dtype in self.DTYPE)
-
-        # reset the outputs
-        dat.dtype.names = new_names
-
-        return dat
-
     def __bool__(self):
         """
         Method to enable to boolean testing based on the count
@@ -783,27 +760,39 @@ class SED:
             np.savetxt(filename, self.data, delimiter=delimiter, fmt=self.FORMAT,
                        header=delimiter.join(self._data.dtype.names))
 
-    def as_HDU(self, **kwargs):
+    def as_HDU(self, header=None):
         """
-        Method to package the spectrum in to an `astropy.io.fits.BinTableHDU`
+        Method to rename the internal numpy columns for a more descriptive
+        output in the fits tables
 
-        Parameters
-        ----------
-        kwargs : dict, optional
-            Keyword/value pairs set as header keyword/value pairs
-
+        Returns
+        -------
+        hdu : `fits.astropy.io.BinTableHDU()`
+           This will be a structured numpy array with descriptive column names
         """
 
-        fluxunits = Config().fluxunits
+        # get the data locally and trim the padding
+        data = self.data
 
-        hdu = fits.BinTableHDU(self.data)
+        # get the new names by remapping the internal names to better
+        # external names for the ouptut files
+        new_names = tuple(self.EXTKEYS[inkey] for inkey, dtype in self.DTYPE)
 
-        hdu.header.set('TUNIT1', value='angstrom', after='TFORM1')
-        hdu.header.set('TUNIT2', value=fluxunits, after='TFORM2')
-        hdu.header.set('TUNIT3', value=fluxunits, after='TFORM3')
-        hdu.header.set('TUNIT4', value=fluxunits, after='TFORM4')
-        hdu.header.set('TUNIT5', value='number', after='TFORM5')
+        # reset the outputs
+        data.dtype.names = new_names
 
-        for k, v in kwargs.items():
-            hdu.header[k] = v
+        # put into an HDU
+        hdu = fits.BinTableHDU(data, header=header)
+
+        # get units of the spectrum
+        cfg = Config()
+        fluxunit = f'{cfg.fluxscale} {cfg.fluxunits}'
+
+        # update the output units
+        hdu.data.columns['WAVELENGTH'].unit = 'Angstrom'
+        hdu.data.columns['FLUX'].unit = fluxunit
+        hdu.data.columns['UNCERTAINTY'].unit = fluxunit
+        hdu.data.columns['CONTAMINATION'].unit = fluxunit
+        hdu.data.columns['NMEASUREMENTS'].unit = ''
+
         return hdu

--- a/slitlessutils/core/photometry/sed.py
+++ b/slitlessutils/core/photometry/sed.py
@@ -790,9 +790,9 @@ class SED:
 
         # update the output units in the header
         hdu.header.set('TUNIT1', value='angstrom', after='TFORM1')
-        hdu.header.set('TUNIT2', value=fluxunits, after='TFORM2')
-        hdu.header.set('TUNIT3', value=fluxunits, after='TFORM3')
-        hdu.header.set('TUNIT4', value=fluxunits, after='TFORM4')
+        hdu.header.set('TUNIT2', value=fluxunit, after='TFORM2')
+        hdu.header.set('TUNIT3', value=fluxunit, after='TFORM3')
+        hdu.header.set('TUNIT4', value=fluxunit, after='TFORM4')
         hdu.header.set('TUNIT5', value='number', after='TFORM5')
         # update the output units on the data itself
         hdu.data.columns['WAVELENGTH'].unit = 'Angstrom'

--- a/slitlessutils/core/preprocess/background/background.py
+++ b/slitlessutils/core/preprocess/background/background.py
@@ -15,14 +15,14 @@ from ...utilities import headers
 from ...wfss import WFSS
 
 
-def background_processing(mastersky=False):
+def background_processing(globalsky=False):
     """
     A decorator so that all background methods prep the data in the same way
 
     Parameters
     ----------
-    mastersky : bool, optional
-        flag to read master sky image
+    globalsky : bool, optional
+        flag to read global sky image
 
     """
 
@@ -36,9 +36,9 @@ def background_processing(mastersky=False):
 
             # load it as an observed image
             data = WFSS.observed(filename)
-            if mastersky:
+            if globalsky:
                 # get the name of the background file:
-                backfile = data.background_filename('master')
+                backfile = data.background_filename('global')
 
             with fits.open(filename, mode=mode) as hdul:
                 # will need the primary header below
@@ -72,20 +72,20 @@ def background_processing(mastersky=False):
                             gpx = (dqa == 0)      # these are good pixels
                             ave, med, sig = sigma_clipped_stats(sci[gpx], sigma=self.skysigma)
 
-                            # if doing master sky, then need to prep the sky
-                            if mastersky:
+                            # if doing global sky, then need to prep the sky
+                            if globalsky:
                                 if isinstance(backfile, str) and os.path.exists(backfile):
                                     # get the model and check normalization
                                     if phdr.get('SUBARRAY', False):
                                         # In the subarray case, we could have both CCDCHIP and
                                         # EXTVER both be 1, so we need to make sure we get the correct
-                                        # extension from the master background file.
+                                        # extension from the global background file.
                                         if hdr['CCDCHIP'] == 1:
                                             back_vers = 2
                                         elif hdr['CCDCHIP'] == 2:
                                             back_vers = 1
                                         # Warn that results might still be suspect
-                                        msg = ("Master-sky subtraction may give poor results for subarray"
+                                        msg = ("Global-sky subtraction may give poor results for subarray"
                                                f"data, especially for small subarrays: {filename}")
                                         LOGGER.knownissue(msg)
                                     else:
@@ -95,7 +95,7 @@ def background_processing(mastersky=False):
 
                                     a, m, s = sigma_clipped_stats(mod)
                                     if np.abs(a - 1) > 1e-2:
-                                        msg = (f'The master sky image ({backfile}) is '
+                                        msg = (f'The global sky image ({backfile}) is '
                                                f'unnormalized {a}. Results will be fine, '
                                                f'but the values may be suspect.')
                                         LOGGER.warning(msg)
@@ -110,7 +110,7 @@ def background_processing(mastersky=False):
 
                                     ret, src = func(self, sci, hdr, unc, med, gpx, mod, **kwargs)
                                 else:
-                                    msg = f'The master-sky image is invalid: {backfile}.  ' + \
+                                    msg = f'The global-sky image is invalid: {backfile}.  ' + \
                                         'No subtraction performed.'
                                     LOGGER.warning(msg)
                                     ret = 0.
@@ -272,12 +272,12 @@ class Background:
         # return the sky pixels (ie those that are *NOT* sources)
         return np.logical_not(src)
 
-    @background_processing(mastersky=True)
-    def master(self, sci, hdr, unc, mod, gpx, img):
+    @background_processing(globalsky=True)
+    def image(self, sci, hdr, unc, mod, gpx, img):
         r"""
-        Function to fit a *single* master sky image to a WFSS image.
+        Function to fit a *single* global sky image to a WFSS image.
 
-        The master-sky image is a two-dimensional model of the dispersed
+        The global-sky image is a two-dimensional model of the dispersed
         sky background.  Ideally, this image is scaled to match the background
         pixels in a dispersed image, however requires flagging all of the
         pixels that contain any additional signal (such as, but not limited to,
@@ -333,7 +333,7 @@ class Background:
         Returns
         -------
         outfile : str
-           The name of the master-sky subtracted file.
+           The name of the global-sky subtracted file.
         """
         # do inverse-variance weighting:
         sci2 = sci / np.maximum(unc, self.MINUNC)
@@ -384,7 +384,7 @@ class Background:
 
         # update the header
         self.update_header(hdr)
-        hdr.set('METHOD', value='master', comment='method')
+        hdr.set('METHOD', value='global', comment='method')
         hdr.set('ALPHA', value=alpha,
                 comment='Normalization of sky model')
 
@@ -393,7 +393,7 @@ class Background:
 
         return out, np.logical_not(sky)
 
-    @background_processing(mastersky=False)
+    @background_processing(globalsky=False)
     def constant(self, sci, hdr, unc, mod, gpx):
         r"""
         Function to fit a constant background to a WFSS image, which
@@ -408,7 +408,7 @@ class Background:
         Returns
         -------
         outfile : str
-           The name of the master-sky subtracted file.
+           The name of the global-sky subtracted file.
         """
         # find the initial sky pixels
         sky = self.skypixels(sci, unc, mod)
@@ -445,7 +445,7 @@ class Background:
 
         return out, np.logical_not(sky)
 
-    @background_processing(mastersky=False)
+    @background_processing(globalsky=False)
     def poly1d(self, sci, hdr, unc, mod, gpx, degree=2, filtwindow=51, filtorder=1):
         r"""
         Method to fit polynomials in the cross-dispersion axis and
@@ -477,7 +477,7 @@ class Background:
         Returns
         -------
         outfile : str
-           The name of the master-sky subtracted file.
+           The name of the global-sky subtracted file.
 
 
         Notes
@@ -570,7 +570,7 @@ class Background:
             The fits header to update
         """
 
-        hdr.set('SKYCORR', value=True, comment='Master sky subtracted?')
+        hdr.set('SKYCORR', value=True, comment='Global sky subtracted?')
         hdr.set('SKYNSIG', value=self.skysigma,
                 comment='Nsigma for constant sky model')
         hdr.set('SRCNSIG', value=self.srcsigma,

--- a/slitlessutils/core/preprocess/background/background.py
+++ b/slitlessutils/core/preprocess/background/background.py
@@ -101,7 +101,7 @@ def background_processing(globalsky=False):
                                         LOGGER.warning(msg)
 
                                     # excise if need-be
-                                    if phdr['INSTRUME'] == 'WFC3':
+                                    if phdr['INSTRUME'] in ('WFC3', 'ACS'):
                                         x0 = -int(hdr.get('LTV1', 0))
                                         y0 = -int(hdr.get('LTV2', 0))
                                         nx = hdr['NAXIS1']

--- a/slitlessutils/core/sources/source.py
+++ b/slitlessutils/core/sources/source.py
@@ -10,7 +10,7 @@ from astropy.wcs import WCS
 from astropy.wcs import utils as wcsutils
 from skimage.segmentation import expand_labels
 
-from ...config import CONFIG
+from ...config import Config
 from ...logger import LOGGER
 from ..utilities import headers, indices
 from .dispersedregion import DispersedRegion
@@ -489,13 +489,14 @@ class Source(list):
         hdr['DEC'] = (self.adc[1], 'Declination (deg)')
         hdr['X'] = (self.xyc[0], 'X barycenter')
         hdr['Y'] = (self.xyc[1], 'Y barycenter')
-        hdr['FLUX'] = (self.flux, 'instrumental flux in direct image')
-        hdr['MAG'] = (self.mag, 'AB magnitude in direct image')
-        hdr['FNU'] = (self.fnu, 'flux in erg/s/cm2/Hz in direct image')
+        hdr['IMGFLUX'] = (self.flux, 'instrumental flux in direct image')
+        hdr['IMGMAG'] = (self.mag, 'AB magnitude in direct image')
+        hdr['IMGFNU'] = (self.fnu, 'flux in erg/s/cm2/Hz in direct image')
         hdr['NPIXELS'] = (self.npixels, 'total number of extracted pixels')
         hdr['WHTTYPE'] = (self.whttype, 'Type of source profile weights')
-        hdr['LAMBUNIT'] = ('AA', 'Unit on the wavelength')
-        hdr['FLAMUNIT'] = (f'{Config().fluxunits} erg cm-2 s-1 AA-1', 'Unit on the flamb spectrum')
+        hdr['WAVEUNIT'] = ('AA', 'Unit on the wavelength')
+        hdr['FLUXUNIT'] = (f'{Config().fluxunits} erg cm-2 s-1 AA-1', 'Unit on the flamb spectrum')
+        hdr['FLUXTYPE'] = ('flam', 'Is spectrum `flam` or `fnu` units')
 
         if self.whttype == 'fitprofile':
             hdr['WHTPROF'] = (self.profile, 'The analytic profile for the weights')
@@ -548,11 +549,11 @@ class Source(list):
             # set the data
             dat = np.zeros((hdr['NAXIS3'], hdr['NAXIS2'], hdr['NAXIS1']),
                            dtype=float)
-
+            raise NotImplementedError("three-dimensional extraction is not yet supported")
             hdu = fits.ImageHDU(dat, hdr)
         else:
             # set the data as a single spectrum
-            dat = self[0].sed.data
+            dat = self[0].sed.for_output()
             hdu = fits.BinTableHDU(dat, hdr)
         return hdu
 

--- a/slitlessutils/core/sources/source.py
+++ b/slitlessutils/core/sources/source.py
@@ -10,7 +10,6 @@ from astropy.wcs import WCS
 from astropy.wcs import utils as wcsutils
 from skimage.segmentation import expand_labels
 
-from ...config import Config
 from ...logger import LOGGER
 from ..utilities import headers, indices
 from .dispersedregion import DispersedRegion
@@ -480,81 +479,82 @@ class Source(list):
         If the source is compound, then it will be written with 3-dimensional
             WCS.
         """
-        hdr = fits.Header()
-        hdr['EXTNAME'] = (str(self.segid),)
 
-        hdr['SEGID'] = (self.segid, 'Segmentation ID')
-        hdr['GRPID'] = (kwargs.get('group', self.grpid), 'Group ID')
-        hdr['RA'] = (self.adc[0], 'Right Ascension (deg)')
-        hdr['DEC'] = (self.adc[1], 'Declination (deg)')
-        hdr['X'] = (self.xyc[0], 'X barycenter')
-        hdr['Y'] = (self.xyc[1], 'Y barycenter')
-        hdr['IMGFLUX'] = (self.flux, 'instrumental flux in direct image')
-        hdr['IMGMAG'] = (self.mag, 'AB magnitude in direct image')
-        hdr['IMGFNU'] = (self.fnu, 'flux in erg/s/cm2/Hz in direct image')
-        hdr['NPIXELS'] = (self.npixels, 'total number of extracted pixels')
-        hdr['WHTTYPE'] = (self.whttype, 'Type of source profile weights')
-        hdr['WAVEUNIT'] = ('AA', 'Unit on the wavelength')
-        hdr['FLUXUNIT'] = (f'{Config().fluxunits} erg cm-2 s-1 AA-1', 'Unit on the flamb spectrum')
-        hdr['FLUXTYPE'] = ('flam', 'Is spectrum `flam` or `fnu` units')
+        # make an output header
+        header = fits.Header()
+
+        # make some basic keywords
+        header['EXTNAME'] = (str(self.segid),)
+
+        header['SEGID'] = (self.segid, 'Segmentation ID')
+        header['GRPID'] = (kwargs.get('group', self.grpid), 'Group ID')
+        header['RA'] = (self.adc[0], 'Right Ascension (deg)')
+        header['DEC'] = (self.adc[1], 'Declination (deg)')
+        header['X'] = (self.xyc[0], 'X barycenter')
+        header['Y'] = (self.xyc[1], 'Y barycenter')
+        header['IMGFLUX'] = (self.flux, 'instrumental flux in direct image')
+        header['IMGMAG'] = (self.mag, 'AB magnitude in direct image')
+        header['IMGFNU'] = (self.fnu, 'flux in erg/s/cm2/Hz in direct image')
+        header['NPIXELS'] = (self.npixels, 'total number of extracted pixels')
+        header['WHTTYPE'] = (self.whttype, 'Type of source profile weights')
+        header['FLUXTYPE'] = ('flam', 'Is spectrum `flam` or `fnu` units')
 
         if self.whttype == 'fitprofile':
-            hdr['WHTPROF'] = (self.profile, 'The analytic profile for the weights')
-        hdr['NREGIONS'] = (self.nregions, 'number of spectral regions')
-        hdr['AREA'] = (self.npixels * self.pixelarea, 'source area (arcsec2)')
-        headers.add_stanza(hdr, 'Source Properties', before='SEGID')
+            header['WHTPROF'] = (self.profile, 'The analytic profile for the weights')
+        header['NREGIONS'] = (self.nregions, 'number of spectral regions')
+        header['AREA'] = (self.npixels * self.pixelarea, 'source area (arcsec2)')
+        headers.add_stanza(header, 'Source Properties', before='SEGID')
 
-        hdr['BCKSUB'] = (self.local_back, 'Was local background in direct image subtracted')
-        hdr['BCKSIZE'] = (self.backsize, 'Size of background annulus (in pix)')
-        hdr['BCKVAL'] = (self.background, 'Background level in direct image')
-        hdr['BCKLOSIG'] = (self.nsig[0], 'N sigma for low level')
-        hdr['BCKHISIG'] = (self.nsig[1], 'N sigma for high level')
-        headers.add_stanza(hdr, 'Direct Image Background', before='BCKSUB')
+        header['BCKSUB'] = (self.local_back, 'Was local background in direct image subtracted')
+        header['BCKSIZE'] = (self.backsize, 'Size of background annulus (in pix)')
+        header['BCKVAL'] = (self.background, 'Background level in direct image')
+        header['BCKLOSIG'] = (self.nsig[0], 'N sigma for low level')
+        header['BCKHISIG'] = (self.nsig[1], 'N sigma for high level')
+        headers.add_stanza(header, 'Direct Image Background', before='BCKSUB')
 
         if self.is_compound:
-            hdr['NAXIS'] = (3, 'number of WCS axes')
-            hdr['NAXIS1'] = self.wcs._naxis[0]
-            hdr['NAXIS2'] = self.wcs._naxis[1]
-            # hdr['NAXIS3']=nlam
+            header['NAXIS'] = (3, 'number of WCS axes')
+            header['NAXIS1'] = self.wcs._naxis[0]
+            header['NAXIS2'] = self.wcs._naxis[1]
+            # header['NAXIS3']=nlam
             raise RuntimeError("gotta get nlam")
 
-            hdr['CTYPE1'] = self.wcs.ctype[0]
-            hdr['CTYPE2'] = self.wcs.ctype[1]
-            hdr['CTYPE3'] = 'wavelength (A)'
+            header['CTYPE1'] = self.wcs.ctype[0]
+            header['CTYPE2'] = self.wcs.ctype[1]
+            header['CTYPE3'] = 'wavelength (A)'
 
-            hdr['CRPIX1'] = self.wcs.crpix[0]
-            hdr['CRPIX2'] = self.wcs.crpix[1]
-            hdr['CRPIX3'] = 1
+            header['CRPIX1'] = self.wcs.crpix[0]
+            header['CRPIX2'] = self.wcs.crpix[1]
+            header['CRPIX3'] = 1
 
-            hdr['CRVAL1'] = self.wcs.crval[0]
-            hdr['CRVAL2'] = self.wcs.crval[1]
-            # hdr['CRVAL3']=lam0
+            header['CRVAL1'] = self.wcs.crval[0]
+            header['CRVAL2'] = self.wcs.crval[1]
+            # header['CRVAL3']=lam0
 
-            hdr['LTV1'] = self.ltv[0]
-            hdr['LTV2'] = self.ltv[1]
+            header['LTV1'] = self.ltv[0]
+            header['LTV2'] = self.ltv[1]
 
-            hdr['CD1_1'] = self.wcs.cd[0, 0]
-            hdr['CD1_2'] = self.wcs.cd[0, 1]
-            hdr['CD2_1'] = self.wcs.cd[1, 0]
-            hdr['CD2_2'] = self.wcs.cd[1, 1]
-            # hdr['CD3_3']=dlam
+            header['CD1_1'] = self.wcs.cd[0, 0]
+            header['CD1_2'] = self.wcs.cd[0, 1]
+            header['CD2_1'] = self.wcs.cd[1, 0]
+            header['CD2_2'] = self.wcs.cd[1, 1]
+            # header['CD3_3']=dlam
 
-            hdr['CUNIT1'] = self.wcs.cunit[0]
-            hdr['CUNIT2'] = self.wcs.cunit[1]
-            hdr['CUNIT3'] = 'A'
+            header['CUNIT1'] = self.wcs.cunit[0]
+            header['CUNIT2'] = self.wcs.cunit[1]
+            header['CUNIT3'] = 'A'
 
-            hdr['DISPAXIS'] = (3, 'dispersion axis')
-            headers.add_stanza(hdr, 'WORLD-COORDINATE SYSTEM', before='NAXIS')
+            header['DISPAXIS'] = (3, 'dispersion axis')
+            headers.add_stanza(header, 'WORLD-COORDINATE SYSTEM', before='NAXIS')
 
             # set the data
-            dat = np.zeros((hdr['NAXIS3'], hdr['NAXIS2'], hdr['NAXIS1']),
-                           dtype=float)
+            dim = (header['NAXIS3'], header['NAXIS2'], header['NAXIS1'])
+            dat = np.zeros(dim, dtype=float)
             raise NotImplementedError("three-dimensional extraction is not yet supported")
-            hdu = fits.ImageHDU(dat, hdr)
+            hdu = fits.ImageHDU(dat, header)
         else:
-            # set the data as a single spectrum
-            dat = self[0].sed.for_output()
-            hdu = fits.BinTableHDU(dat, hdr)
+            hdu = self[0].sed.as_HDU(header=header)
+
         return hdu
 
     def image_coordinates(self, x, y, dtype=None):

--- a/slitlessutils/core/sources/source.py
+++ b/slitlessutils/core/sources/source.py
@@ -10,6 +10,7 @@ from astropy.wcs import WCS
 from astropy.wcs import utils as wcsutils
 from skimage.segmentation import expand_labels
 
+from ...config import CONFIG
 from ...logger import LOGGER
 from ..utilities import headers, indices
 from .dispersedregion import DispersedRegion
@@ -493,6 +494,9 @@ class Source(list):
         hdr['FNU'] = (self.fnu, 'flux in erg/s/cm2/Hz in direct image')
         hdr['NPIXELS'] = (self.npixels, 'total number of extracted pixels')
         hdr['WHTTYPE'] = (self.whttype, 'Type of source profile weights')
+        hdr['LAMBUNIT'] = ('AA', 'Unit on the wavelength')
+        hdr['FLAMUNIT'] = (f'{Config().fluxunits} erg cm-2 s-1 AA-1', 'Unit on the flamb spectrum')
+
         if self.whttype == 'fitprofile':
             hdr['WHTPROF'] = (self.profile, 'The analytic profile for the weights')
         hdr['NREGIONS'] = (self.nregions, 'number of spectral regions')

--- a/slitlessutils/core/sources/source.py
+++ b/slitlessutils/core/sources/source.py
@@ -142,13 +142,12 @@ class Source(list):
             # get a bounding box
             x0 = max(np.amin(x) - self.backsize, 0)
             y0 = max(np.amin(y) - self.backsize, 0)
-            x1 = min(np.amax(x) + self.backsize, img.shape[1] - 1)
-            y1 = min(np.amax(y) + self.backsize, img.shape[0] - 1)
+            x1 = min(np.amax(x) + self.backsize, img.shape[1])
+            y1 = min(np.amax(y) + self.backsize, img.shape[0])
 
             # cut out regions
             subimg = img[y0:y1, x0:x1]
             subseg = seg[y0:y1, x0:x1]
-            # subwht = wht[y0:y1, x0:x1]
 
             # compute and subtract the local sky background:
             if self.local_back:
@@ -170,8 +169,8 @@ class Source(list):
                 self.background = 0.0
 
             # convert the image into weights
-            w = self.compute_weights(subimg, x - x0, y - y0, whttype=whttype, profile=profile,
-                                     negfunc=negfunc, epsilon=1e-9)
+            w = self.compute_weights(subimg, x - x0, y - y0, whttype=whttype,
+                                     profile=profile, negfunc=negfunc, epsilon=1e-9)
 
             # remove pixels with zero weights
             g = np.where(w > 0)[0]
@@ -264,8 +263,9 @@ class Source(list):
             # else:
             #     LOGGER.warning(f"Ignoring {segid=}")
 
-    def compute_weights(self, subimg, x, y, whttype='pixels', profile='gaussian',
-                        negfunc='positivity', epsilon=1e-9):
+    def compute_weights(self, subimg, x, y, whttype='pixels',
+                        profile='gaussian', negfunc='positivity',
+                        epsilon=1e-9):
 
         # set some variables
         self.profile = profile.lower()

--- a/slitlessutils/core/utilities/compression.py
+++ b/slitlessutils/core/utilities/compression.py
@@ -1,4 +1,3 @@
-# import subprocess
 import gzip
 import os
 import shutil

--- a/slitlessutils/core/wfss/data/wfss.py
+++ b/slitlessutils/core/wfss/data/wfss.py
@@ -633,6 +633,18 @@ class WFSS(dict):
 
         return '\n'.join(s)
 
+    def primaryheader(self):
+        """
+        Method to read the primary header
+
+        Returns
+        -------
+        phdr : `astropy.io.fits.Header`
+            The primary header.
+        """
+        phdr = fits.getheader(self.filename, 0)
+        return phdr
+
     def extensions(self):
         """
         An iterator to loop over the detectors and all possible extensions

--- a/slitlessutils/examples/__init__.py
+++ b/slitlessutils/examples/__init__.py
@@ -1,5 +1,7 @@
 from . import acswfc  # noqa: F401
+from . import extract_multi  # noqa: F401
 from . import ring  # noqa: F401
+from . import simulate  # noqa: F401
 from . import starfield  # noqa: F401
 from . import wfc3ir  # noqa: F401
 from . import wfc3uvis  # noqa: F401

--- a/slitlessutils/examples/acswfc.py
+++ b/slitlessutils/examples/acswfc.py
@@ -90,8 +90,8 @@ def preprocess_grism():
         for line in fp:
             grismfile = line.strip()
 
-            # subtract background via master-sky
-            back.master(grismfile, inplace=True)
+            # subtract background via global-sky technique
+            back.image(grismfile, inplace=True)
 
             # downgrade the WCS to be consistent
             su.core.preprocess.astrometry.downgrade_wcs(grismfile, key='A',
@@ -208,16 +208,16 @@ def plot_spectra():
 
     # load the data and change the units
     dat, hdr = fits.getdata(f'{ROOT}_x1d.fits', header=True)
-    dat['flam'] *= cfg.fluxscale / 1e-13
-    dat['func'] *= cfg.fluxscale / 1e-13
+    dat['FLUX'] *= cfg.fluxscale / 1e-13
+    dat['UNCERTAINTY'] *= cfg.fluxscale / 1e-13
 
     # get a good range of points to compute a (variance-weighted) scale factor
     lmin = 7350.
     lmax = 8120.
-    g = np.where((lmin <= dat['lamb']) & (dat['lamb'] <= lmax))[0]
-    ff2 = np.interp(dat['lamb'], l, ff)
-    obssn = dat['flam'][g] / dat['func'][g]
-    calsn = ff2[g] / dat['func'][g]
+    g = np.where((lmin <= dat['WAVELENGTH']) & (dat['WAVELENGTH'] <= lmax))[0]
+    ff2 = np.interp(dat['WAVELENGTH'], l, ff)
+    obssn = dat['FLUX'][g] / dat['UNCERTAINTY'][g]
+    calsn = ff2[g] / dat['UNCERTAINTY'][g]
     den = np.nansum(obssn * obssn)
     num = np.nansum(calsn * obssn)
     scl = num / den
@@ -228,7 +228,7 @@ def plot_spectra():
 
     # plot the SU spectrum
     plt.axvspan(lmin, lmax, color='lightgrey')
-    plt.plot(dat['lamb'], dat['flam'], label='slitlessutils')
+    plt.plot(dat['WAVELENGTH'], dat['FLUX'], label='slitlessutils')
     plt.plot(l, ff / scl, label='Pasquali et al. (2002) $-$ smoothed')
 
     # uncomment this to see the hi-res file.

--- a/slitlessutils/examples/acswfc.py
+++ b/slitlessutils/examples/acswfc.py
@@ -19,7 +19,7 @@ Description
 This file demonstrates the analysis of HST ACS/WFC grism spectroscopy using
 the G800L observations of the standard star WR96.  It will compare the
 spectrum extracted with slitlessutils to a reference spectrum from
-Pasquali et al. (2002) that is stored in the reference file database.
+Pasquali et al. (2001) that is stored in the reference file database.
 
 The grey bar shows the region used to normalize the spectra.
 
@@ -202,7 +202,7 @@ def plot_spectra():
 
     # smooth the A. Pasquali reference spectrum (kindly provided S. Larsen).
     # the Scale factor is from comparing the notional ACS dispersion
-    # (40A/pix) to the spectrum quoted from Pasquali+ 2002 which has
+    # (40A/pix) to the spectrum quoted from Pasquali+ 2001 which has
     # 1.26 A/pix. Therefore smoothing factor is 40./1.26 = 31.7
     ff = gaussian_filter1d(f, 31.7)
 

--- a/slitlessutils/examples/extract_multi.py
+++ b/slitlessutils/examples/extract_multi.py
@@ -59,18 +59,18 @@ def makeplot():
         for i, hdu in enumerate(hdul[1:]):
             data = hdu.data
 
-            nnan = np.sum(np.isnan(data['flam']))
-            ntot = len(data['flam'])
+            nnan = np.sum(np.isnan(data['FLUX']))
+            ntot = len(data['FLUX'])
 
             if nnan != ntot:
                 segid = hdu.header['SEGID']
 
-                xerr = (data['lamb'][1] - data['lamb'][0]) / 2
-                xerr = np.full_like(data['lamb'], xerr)
+                xerr = (data['WAVELENGTH'][1] - data['WAVELENGTH'][0]) / 2
+                xerr = np.full_like(data['WAVELENGTH'], xerr)
 
-                plt.plot(data['lamb'], data['flam'], color='darkgrey')
-                plt.errorbar(data['lamb'], data['flam'],
-                             xerr=xerr, yerr=data['func'],
+                plt.plot(data['WAVELENGTH'], data['FLUX'], color='darkgrey')
+                plt.errorbar(data['WAVELENGTH'], data['FLUX'],
+                             xerr=xerr, yerr=data['UNCERTAINTY'],
                              color='black', label='multi_extract', fmt='o')
 
                 specfile = os.path.join('spectra', f'{segid}_1.csv')

--- a/slitlessutils/examples/extract_multi.py
+++ b/slitlessutils/examples/extract_multi.py
@@ -1,8 +1,8 @@
 import os
 
-from astropy.io import fits
 import matplotlib.pyplot as plt
 import numpy as np
+from astropy.io import fits
 
 import slitlessutils as su
 

--- a/slitlessutils/examples/extract_multi.py
+++ b/slitlessutils/examples/extract_multi.py
@@ -1,0 +1,107 @@
+import os
+
+from astropy.io import fits
+import matplotlib.pyplot as plt
+import numpy as np
+
+import slitlessutils as su
+
+ROOT = 'pointsources'
+
+# parameters for the set up of the instrument
+TELESCOPE = 'HST'
+INSTRUMENT = 'WFC3'
+DETECTOR = 'IR'
+WRANGE = (7500., 11000.)
+
+SUFFIX = 'flt'
+SEDPATH = 'cdbs'
+
+
+def getPrefix(ins):
+    if ins == 'WFC3':
+        return 'i'
+    elif ins == 'ACS':
+        return 'j'
+    else:
+        raise NotImplementedError("Invalid instrument")
+
+
+def extract_multi():
+    ins = getPrefix(INSTRUMENT)
+
+    # load the grism images
+    data = su.wfss.data.WFSSCollection.from_glob(f'{ins}*_{SUFFIX}.fits.gz')
+
+    # load the sources into SU
+    sources = su.sources.SourceCollection(f'{ROOT}_seg.fits',
+                                          f'{ROOT}_sci.fits',
+                                          local_back=False)
+
+    # test grouping
+    grp = su.modules.Group(ncpu=1, orders=('+1',))
+    groups = grp(data, sources)
+    groups.plot(f'{ROOT}_grp.pdf')
+
+    # run the single-file extraction
+    ext = su.modules.Multi('+1', (-5., 0, 0.1), root=ROOT, algorithm='grid')
+    res = ext(data, sources, groups=groups)
+    return res
+
+
+def makeplot():
+    fluxscale = su.config.Config().fluxscale
+
+    AA = '\\mathrm{\\AA}'
+    filename = f'{ROOT}_x1d.fits'
+    with fits.open(filename, mode='readonly') as hdul:
+
+        for i, hdu in enumerate(hdul[1:]):
+            data = hdu.data
+
+            nnan = np.sum(np.isnan(data['flam']))
+            ntot = len(data['flam'])
+
+            if nnan != ntot:
+                segid = hdu.header['SEGID']
+
+                xerr = (data['lamb'][1] - data['lamb'][0]) / 2
+                xerr = np.full_like(data['lamb'], xerr)
+
+                plt.plot(data['lamb'], data['flam'], color='darkgrey')
+                plt.errorbar(data['lamb'], data['flam'],
+                             xerr=xerr, yerr=data['func'],
+                             color='black', label='multi_extract', fmt='o')
+
+                specfile = os.path.join('spectra', f'{segid}_1.csv')
+                l, f = np.loadtxt(specfile, usecols=(0, 1), delimiter=',',
+                                  skiprows=1, unpack=True)
+
+                g = np.where((WRANGE[0] <= l) & (l <= WRANGE[1]))
+                l = l[g]
+                f = f[g] / fluxscale
+                plt.plot(l, f, color='red', label='CRDS')
+
+                ymin = np.amin(f)
+                ymax = np.amax(f)
+                plt.ylim((0.95 * ymin, 1.05 * ymax))
+                plt.ylabel(r'$f_\lambda$ ($10^{-17}$ erg/s/cm$^2$/' + AA + ')')
+
+                plt.xlim(*WRANGE)
+                plt.xlabel(r'$\lambda_\mathrm{obs}$ (' + AA + ')')
+
+                plt.legend()
+                plt.tight_layout()
+                plt.show()
+
+
+def run_all(plot=False):
+
+    extract_multi()
+
+    if plot:
+        makeplot()
+
+
+if __name__ == '__main__':
+    run_all()

--- a/slitlessutils/examples/simulate.py
+++ b/slitlessutils/examples/simulate.py
@@ -1,10 +1,10 @@
 import os
 import warnings
 
+import numpy as np
 from astropy.io import fits
 from astropy.modeling import models
 from astropy.wcs import WCS
-import numpy as np
 
 import slitlessutils as su
 

--- a/slitlessutils/examples/simulate.py
+++ b/slitlessutils/examples/simulate.py
@@ -1,0 +1,183 @@
+import os
+import warnings
+
+from astropy.io import fits
+from astropy.modeling import models
+from astropy.wcs import WCS
+import numpy as np
+
+import slitlessutils as su
+
+ROOT = 'pointsources'
+
+# parameters for the set up of the instrument
+TELESCOPE = 'HST'
+INSTRUMENT = 'WFC3'
+DETECTOR = 'IR'
+DISPERSER = 'G102'
+BLOCKING = ''
+FILTER = 'F105W'
+WRANGE = (7500., 11000.)
+SUFFIX = 'flt'
+EXPTIME = 1000.
+
+# Notional Field Parameters
+RA = 53.
+DEC = -27.
+PIXSCL = 0.06
+SIZE = (100, 100)
+NCPU = 1
+
+# make some random data
+SEED = 42                    # set a random seed to control
+NOBJ = 5                     # number of point sources to simulate
+NIMG = 5                     # number of random images
+MRANGE = (17., 20.)          # range of magnitude (in FILTER)
+APERRAD = 0.3                # radius of the segmentation
+PSFSIG = 1.5                 # the PSF sigma
+SEDPATH = 'cdbs'
+
+
+def make_scene():
+    np.random.seed(SEED)
+
+    # create something to store the SEDs that will be used for the simulation
+    hdul = fits.HDUList()
+
+    # make a direct and segmentation image
+    img = np.zeros(SIZE, dtype=float)
+    seg = np.zeros_like(img, dtype=int)
+    xim, yim = np.meshgrid(np.arange(SIZE[0]), np.arange(SIZE[1]))
+
+    # create a morphological function for the sources
+    func = models.Gaussian2D(x_stddev=PSFSIG, y_stddev=PSFSIG)
+
+    # read the filter curve
+    band = su.photometry.Throughput.from_keys(TELESCOPE, INSTRUMENT, FILTER)
+
+    # make dir to stage the SEDs from CDBS
+    os.makedirs(SEDPATH, exist_ok=True)
+
+    # radius for the segmaps
+    radius = APERRAD / PIXSCL
+
+    # process each
+    for segid in range(1, NOBJ + 1):
+
+        # make random positions/magnitude for each source
+        x = np.random.uniform(low=0, high=SIZE[0])
+        y = np.random.uniform(low=0, high=SIZE[0])
+        m = np.random.uniform(low=MRANGE[0], high=MRANGE[1])
+
+        # get a spectral file
+        idx = np.random.randint(low=1, high=131)
+        basename = f'pickles_uk_{idx}.fits'
+        localfile = os.path.join(SEDPATH, basename)
+        if not os.path.exists(localfile):
+            localfile = su.photometry.SED.get_from_CDBS('pickles', basename,
+                                                        outpath=SEDPATH)
+            if localfile is None:
+                warnings.warn("Did not download file.  May cause problems.",
+                              RuntimeWarning)
+
+        hdr = fits.Header()
+        hdr['EXTNAME'] = (str(segid), 'segmentation ID')
+        hdr['EXTVER'] = (0, 'spectral region')
+        hdr['FILENAME'] = (localfile, 'filename')
+        hdul.append(fits.TableHDU(header=hdr))
+
+        # problem here.  Astropy uses "amplitude" as the overall
+        # normalization of the spatial profile, even though what we want
+        # is the total flux to be specified.  Of course for some analytic
+        # profiles, this amplitude can be determined, however I want
+        # to leave the profile flexible, so will determine the conversion
+        # between amplitude and total by just scaling via a "delta"
+        # image (called dimg)
+
+        # evaluate the point source
+        func.x_mean = x
+        func.y_mean = y
+        func.amplitude = 1.
+        dimg = func(xim, yim)
+
+        # do the normalization
+        ftot = 10.**(-0.4 * (m - band.zeropoint))
+
+        # scale the delta image and add into the image
+        img += (ftot * (dimg / np.sum(dimg)))
+
+        # compute an aperture for the segmap
+        rim = np.hypot(xim - x, yim - y)
+        seg = np.where(rim < radius, segid, seg)
+
+    # make a WCS
+    w = WCS(naxis=2)
+    w.wcs.crpix = (SIZE[0] / 2., SIZE[1] / 2.)
+    w.wcs.crval = (RA, DEC)
+    w.wcs.ctype = ('RA---TAN', 'DEC--TAN')
+    w.wcs.cd = ((-PIXSCL / 3600., 0.), (0., PIXSCL / 3600.))
+
+    # make a header
+    h = w.to_header()
+    h['TELESCOP'] = TELESCOPE
+    h['INSTRUME'] = INSTRUMENT
+    h['FILTER'] = FILTER
+    h['ZERO'] = band.zeropoint
+
+    # save the images
+    fits.writeto(f'{ROOT}_seg.fits', seg, header=h, overwrite=True)
+    fits.writeto(f'{ROOT}_sci.fits', img, header=h, overwrite=True)
+    hdul.writeto(f'{ROOT}_seds.fits', overwrite=True)
+
+
+def getPrefix(ins):
+    if ins == 'WFC3':
+        return 'i'
+    elif ins == 'ACS':
+        return 'j'
+    else:
+        raise NotImplementedError("Invalid instrument")
+
+
+def simulate_grisms(tabulate=False):
+    ins = getPrefix(INSTRUMENT)
+
+    # make a file that describes the WCS of the grism images to be made
+    # nota bene: these columns can be in any order
+    wcsfile = f'{ROOT}_wcs.csv'
+    with open(wcsfile, 'w') as fp:
+        print('dataset,ra,dec,orientat,telescope,instrument,exptime,disperser,blocking', file=fp)
+        for i in range(1, NIMG + 1):
+            dataset = f'{ins}{i:07}q'
+            orientat = i * (180. / NIMG)
+            print(dataset, RA, DEC, orientat, TELESCOPE, INSTRUMENT + DETECTOR,
+                  EXPTIME, DISPERSER, BLOCKING, sep=',', file=fp)
+
+    # load the grism images
+    data = su.wfss.WFSSCollection.from_wcsfile(wcsfile)
+
+    # load the sources
+    sources = su.sources.SourceCollection(f'{ROOT}_seg.fits',
+                                          f'{ROOT}_sci.fits',
+                                          local_back=False,
+                                          sedfile=f'{ROOT}_seds.fits')
+
+    # project the sources onto the grism images
+    if tabulate:
+        tab = su.modules.Tabulate(ncpu=NCPU)
+        _ = tab(data, sources)
+
+    # use the projection tables and the SEDs to simulate grism images
+    sim = su.modules.Simulate(ncpu=NCPU)
+    imgfiles = sim(data, sources)  # noqa: F841
+
+
+def run_all():
+
+    make_scene()
+
+    simulate_grisms(tabulate=True)
+
+
+if __name__ == '__main__':
+    run_all()

--- a/slitlessutils/examples/starfield.py
+++ b/slitlessutils/examples/starfield.py
@@ -381,17 +381,18 @@ def compare(nsig=1.):
                     s = str(segid)
                     if s in hdul:
                         hdu = hdul[s]
-                        flam = hdu.data['flam']
+                        flam = hdu.data['FLUX']
                         if label == 'single-exposure':
                             flam -= hdu.data['cont']
 
-                        lo = flam - nsig * hdu.data['func']
-                        hi = flam + nsig * hdu.data['func']
+                        lo = flam - nsig * hdu.data['UNCERTAINTY']
+                        hi = flam + nsig * hdu.data['UNCERTAINTY']
 
-                        patch = ax.fill_between(hdu.data['lamb'], lo, hi,
+                        patch = ax.fill_between(hdu.data['WAVELENGTH'], lo, hi,
                                                 color=c, alpha=0.2)
-                        meas = ax.plot(hdu.data['lamb'], flam, color=c)
-                        contplot = ax.plot(hdu.data['lamb'], hdu.data['cont'], color='magenta')
+                        meas = ax.plot(hdu.data['WAVELENGTH'], flam, color=c)
+                        contplot = ax.plot(hdu.data['WAVELENGTH'],
+                                           hdu.data['cont'], color='magenta')
 
                         if first:
                             artists.append((patch, meas[0]))

--- a/slitlessutils/examples/wfc3ir.py
+++ b/slitlessutils/examples/wfc3ir.py
@@ -85,8 +85,8 @@ def preprocess_grism():
         for line in fp:
             grismfile = line.strip()
 
-            # subtract the background
-            back.master(grismfile, inplace=True)
+            # subtract the background with the global sky technique
+            back.image(grismfile, inplace=True)
 
             # update the astrometry
             su.core.preprocess.astrometry.downgrade_wcs(grismfile, key='A',
@@ -152,7 +152,7 @@ def extract_single(tabulate=False):
                                           local_back=False,
                                           zeropoint=ZEROPOINT)
 
-    reg = su.modules.Region()
+    reg = su.modules.Region(ncpu=1)
     regfiles = reg(data, sources)  # noqa: F841
 
     # project the sources onto the grism images
@@ -203,11 +203,11 @@ def plot_spectra():
 
     # compute the relative offset
     lrange = (8000, 11550)
-    g = np.where((lrange[0] < dat['lamb']) & (dat['lamb'] < lrange[1]))
-    fint = np.interp(dat['lamb'][g], cs['WAVELENGTH'], cs['FLUX'])
-    num = np.sum((dat['flam'][g] / dat['func'][g]) * (fint / dat['func'][g]))
-    den = np.sum((dat['flam'][g] / dat['func'][g])
-                 * (dat['flam'][g] / dat['func'][g]))
+    g = np.where((lrange[0] < dat['WAVELENGTH']) & (dat['WAVELENGTH'] < lrange[1]))
+    fint = np.interp(dat['WAVELENGTH'][g], cs['WAVELENGTH'], cs['FLUX'])
+    num = np.sum((dat['FLUX'][g] / dat['UNCERTAINTY'][g]) * (fint / dat['UNCERTAINTY'][g]))
+    den = np.sum((dat['FLUX'][g] / dat['UNCERTAINTY'][g])
+                 * (dat['FLUX'][g] / dat['UNCERTAINTY'][g]))
     scl = num / den
     dif = np.abs(scl - 1) * 100.
 
@@ -230,9 +230,9 @@ def plot_spectra():
 
     # plot the two spectra
     ax[0].errorbar(
-        dat['lamb'],
-        dat['flam'],
-        yerr=dat['func'],
+        dat['WAVELENGTH'],
+        dat['FLUX'],
+        yerr=dat['UNCERTAINTY'],
         label='slitlessutils')
     ax[0].plot(cs['WAVELENGTH'], cs['FLUX'], label='CALSPEC')
 

--- a/slitlessutils/examples/wfc3uvis.py
+++ b/slitlessutils/examples/wfc3uvis.py
@@ -196,7 +196,7 @@ def plot_spectra():
     axe['FERROR'] /= cfg.fluxscale
 
     # make the plot
-    plt.plot(dat['lamb'], dat['flam'], label='slitlessutils')
+    plt.plot(dat['WAVELENGTH'], dat['FLUX'], label='slitlessutils')
     plt.plot(axe['LAMBDA'], axe['FLUX'], label='aXe')
 
     plt.legend()

--- a/slitlessutils/tests/test_acs_grism.py
+++ b/slitlessutils/tests/test_acs_grism.py
@@ -120,8 +120,8 @@ def test_ACS_grism(tmp_path):
     # load the data and change the units
     cfg = su.config.Config()
     dat, hdr = fits.getdata(f'{ROOT}_x1d.fits', header=True)
-    dat['flam'] *= cfg.fluxscale / 1e-13
-    dat['func'] *= cfg.fluxscale / 1e-13
+    dat['FLUX'] *= cfg.fluxscale / 1e-13
+    dat['UNCERTAINTY'] *= cfg.fluxscale / 1e-13
 
     assert dat.shape == (119,)
     assert np.allclose(dat[1], (5620.0, 0.029815594, 0.00016166682, 0.0, 13))


### PR DESCRIPTION
This is a major update that addresses the issues with the multi-orient extraction.  Specifically, this will:

1. completely renovate the way the matrix is constructed.  This new implementation is significantly simpler by using more facility from `scipy.sparse`.  It also uses the `CSR_matrix` representation to improve memory usage, remove rows (which represent pixels) that have no constraints, and efficient computation (the bottleneck was in doing a few sorting operations, and `CSR_matrix` avoids that).  
2.  implements the grouping methods.  The grouping algorithm identifies spectral traces that overlap, clusters these sources/orders, and does the multi-orient extraction on the groups.  This is effectively block-diagonalizing the matrix and operating on the blocks sequentially.  The grouping algorithm uses the `networkx` package to efficiently cluster the objects.  The `GroupCollection()` will permit drawing the networks for visualizing the contamination topology.
3.  new examples.  This created 2 new example files to show how to simulate a large field of view and use the multi orient extraction both with and without grouping.
4. a host of minor fixes.  In doing this, a few minor things had to be updated.