### PR TITLE
fixed a few bugs

### DIFF
--- a/slitlessutils/core/modules/extract/single/boxcar.py
+++ b/slitlessutils/core/modules/extract/single/boxcar.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+from astropy.io import fits
 from astropy.stats import sigma_clipped_stats
 
 from .....config import Config
@@ -38,8 +39,9 @@ def boxcar(source, det, sci, unc, dqa, flatfield, order, odt, chdu,
     odt : `slitlessutils.core.tables.ODT`
        The object-dispersion table (ODT).
 
-    chdu : `fits.ImageHDU()`
-       The contamination data
+    chdu : `fits.ImageHDU()` or `None`
+       The contamination data.  If this is a valid `fits.ImageHDU()`, then a
+       contamination model will be computed.  Otherwise, it will not.
 
     width : int or float
        The extraction width in pixels.  Default is 15 pix
@@ -135,17 +137,23 @@ def boxcar(source, det, sci, unc, dqa, flatfield, order, odt, chdu,
                 calsci = (sci[ys, xs] / calib)
                 calvar = (unc[ys, xs] / calib)**2
 
-                # compute the contamination, but recall, we store the
-                # contamination image in a cut out.... So have to get the
-                # apply that offset from the LTV1/2 keywords
-                xc = xs + chdu.header['LTV1']
-                yc = ys + chdu.header['LTV2']
-                calcnt = chdu.data[yc, xc]
-
                 # sum the data with calibrations applied
                 flam = np.sum(calsci * aper)
-                cont = np.sum(calcnt * aper)
                 fvar = np.sum(calvar * aper)
+
+                # sort out the contamination
+                if isinstance(chdu, fits.ImageHDU):
+                    # compute the contamination, but recall, we store the
+                    # contamination image in a cut out.... So have to get the
+                    # apply that offset from the LTV1/2 keywords
+                    xc = xs + chdu.header['LTV1']
+                    yc = ys + chdu.header['LTV2']
+                    contam = chdu.data[yc, xc]
+                    cont = np.sum(contam * aper)
+                else:
+                    # did no contamination
+                    cont = 0.0
+
             else:
                 flam = np.inf
                 fvar = np.inf

--- a/slitlessutils/core/modules/extract/single/contamination.py
+++ b/slitlessutils/core/modules/extract/single/contamination.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
-from astropy.io import fits
 import numpy as np
+from astropy.io import fits
 
 from .....logger import LOGGER
 from ....utilities import headers, indices

--- a/slitlessutils/core/modules/extract/single/contamination.py
+++ b/slitlessutils/core/modules/extract/single/contamination.py
@@ -1,8 +1,12 @@
-import numpy as np
+from collections import namedtuple
+
 from astropy.io import fits
+import numpy as np
 
 from .....logger import LOGGER
 from ....utilities import headers, indices
+
+ContaminationKey = namedtuple('ContaminationTuple', ('segid', 'ordname'))
 
 
 class ContaminantOrders:
@@ -116,7 +120,8 @@ class Contamination(dict):
             for segid, source in sources.items():
                 poly = h5.load_polygon(source)
                 if poly:
-                    self[(segid, ordname)] = poly
+                    key = ContaminationKey(segid, ordname)
+                    self[key] = poly
 
     def __call__(self, segid, ordname, h5, sources, detdata, flatfield, bbx=None, bby=None):
         """
@@ -155,9 +160,9 @@ class Contamination(dict):
 
         """
 
-        # grab the polygon
-        key = (segid, ordname)
-        poly = self[key]
+        # grab the polygon for this given object
+        objkey = ContaminationKey(segid, ordname)
+        objpoly = self[objkey]
 
         if bbx is None:
             bbx = (0, detdata.naxis[0] - 1)
@@ -171,20 +176,20 @@ class Contamination(dict):
         img = np.zeros((ny, nx), dtype=float)
 
         # process each polygon
-        for k, ply in self.items():
+        for contkey, contpoly in self.items():
 
             # ignore if it's the polygon in question
-            if k != key:
+            if contkey != objkey:
 
                 # find out if it overlaps
-                dp = poly.intersection(ply)
+                dp = objpoly.intersection(contpoly)
                 if not dp.is_empty:
 
                     # load the data for this order
-                    h5.load_order(ordname)
+                    h5.load_order(contkey.ordname)
 
                     # process each spectral region
-                    for regid, region in sources[k[0]].items():
+                    for regid, region in sources[contkey.segid].items():
                         for x, y in region.pixels(applyltv=True, dtype=int):
                             # load the data
                             pdt = h5.load_pdt(x, y)
@@ -207,7 +212,7 @@ class Contamination(dict):
 
                                 # apply the calibrations for this pixel
                                 flat = flatfield(xg, yg, wav)
-                                sens = detdata.config[ordname].sensitivity(wav)
+                                sens = detdata.config[contkey.ordname].sensitivity(wav)
                                 area = detdata.relative_pixelarea(xg, yg)
                                 flam = region.sed(wav, fnu=False)
                                 val *= (sens * area * flat * flam)
@@ -239,7 +244,7 @@ class Contamination(dict):
         # add an extname and a few things
         hdr['EXTNAME'] = f'{detdata.name},{segid},{ordname}'
         hdr['DETNAME'] = (detdata.name, 'Detector name')
-        hdr['SEGID'] = (segid, 'Segmentation ID for this cont model')
-        hdr['ORDNAME'] = (ordname, 'Order for cont model')
+        hdr['SEGID'] = (objkey.segid, 'Segmentation ID for this cont model')
+        hdr['ORDNAME'] = (objkey.ordname, 'Order for cont model')
 
         return fits.ImageHDU(data=img, header=hdr)

--- a/slitlessutils/core/modules/extract/single/single.py
+++ b/slitlessutils/core/modules/extract/single/single.py
@@ -421,11 +421,9 @@ class Single(Module):
                                 if self.savecont:
                                     chdul.append(chdu)
 
-                                # get the offsets in the contamination image
-                                # xoff = -chdu.header.get('LTV1', 0)
-                                # yoff = -chdu.header.get('LTV2', 0)
                             else:
-                                chdu = fits.ImageHDU()
+                                # this is an empty contamination
+                                chdu = None  # fits.ImageHDU()
 
                             if extmode == 'boxcar':
                                 spectrum = boxcar(source, detdata, sci, unc,

--- a/slitlessutils/core/modules/extract/single/spectraltable.py
+++ b/slitlessutils/core/modules/extract/single/spectraltable.py
@@ -212,17 +212,18 @@ class SpectralTable(dict):
                 flamsum = np.nansum(w * thisflam) / wsum
                 fluxsum = np.nansum(w * thisflux) / wsum
                 flamvar = 1. / np.sqrt(wsum)
+                contsum = np.nansum(w * thiscont) / wsum
             else:
-                flamsum = np.inf
-                fluxsum = np.inf
-                flamvar = np.inf
+                flamsum = np.nan
+                fluxsum = np.nan
+                flamvar = np.nan
+                contsum = np.nan
 
             numb = np.sum(thisnpix)
-            contam = 0.0
 
             # save the results
             spectrum.append(outw[ind], pars.dwave, flamsum,
-                            np.sqrt(flamvar), fluxsum, contam, numb)
+                            np.sqrt(flamvar), fluxsum, contsum, numb)
 
         return spectrum
 

--- a/slitlessutils/core/photometry/band.py
+++ b/slitlessutils/core/photometry/band.py
@@ -41,8 +41,8 @@ class Band:
             where = np.arange(len(wave), dtype=int)
 
         self.unit = unit.lower()
-        self.wave = wave
-        self.tran = tran
+        self.wave = wave.copy()
+        self.tran = tran.copy()
         self.name = name
 
         if self.unit in ('micron', 'microns', 'um'):


### PR DESCRIPTION
This PR fixes three small bugs:

1. @bjkuhn found that if no contamination model is provided, then an error with LTV1/2 is generated.  This is fixed by checking if the contamination model is not None
2. I was shown that the `Band()` class has a bug that it doesn't store a local copy of the data.  So I added `.copy()` to the numpy arrays.
3. The contamination code was (a) not actually connected but fully built. (b) there was a minor bug in mixing contamination models for different spectral orders (for example, if you have a +2 order contaminating a +1 order, it was using the sensitivity curve for the +1, when it should be for the +2).

this fixes those three things.