### PR TITLE
Update install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,12 +16,12 @@ Start by creating an empty conda environment:
 
 .. code-block:: bash
 
-    conda create --name slitlessutils-env "python>=3.11"
+    conda create --name slitlessutils-env "python>=3.12"
     conda activate slitlessutils-env
 
 You may also need to manually install precompiled ``llvmlite`` binaries before installing
 ``slitlessutils`` to avoid an error when building ``numba`` (used by ``slitlessutils`` to
-improve performance) during the installation. This can be done by running ``conda install --channel=numba llvmlite``
+improve performance) during the installation. This can be done by running ``conda install --channel=conda-forge llvmlite``
 in your conda environment before installing ``slitessutils``.
 
 


### PR DESCRIPTION
The problem with Python 3.11 comes when trying to fetch the slitlessutils reference files with Config(). In Python 3.11, the installed tarfile version doesn’t support the filter parameter, which slitlessutils uses when extracting the reffiles from the .tar file.

I had better luck installing llvmlite via conda-forge