### PR TITLE
Use PyPI Trusted Publishing in publish workflow

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -13,8 +13,8 @@ jobs:
     name: Check if change log entry is correct
     runs-on: ubuntu-latest
     steps:
-    - name: Check change log entry
-      uses: scientific-python/action-check-changelogfile@1fc669db9618167166d5a16c10282044f51805c0  # 0.3
-      env:
-        CHANGELOG_FILENAME: CHANGES.rst
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check change log entry
+        uses: scientific-python/action-check-changelogfile@1fc669db9618167166d5a16c10282044f51805c0 # 0.3
+        env:
+          CHANGELOG_FILENAME: CHANGES.rst
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check_milestone.yml
+++ b/.github/workflows/check_milestone.yml
@@ -3,7 +3,7 @@ name: Check PR milestone
 on:
   # So it cannot be skipped.
   pull_request_target:
-    types: [opened, synchronize, milestoned, demilestoned]
+    types: [opened, reopened, synchronize, milestoned, demilestoned]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/check_milestone.yml
+++ b/.github/workflows/check_milestone.yml
@@ -17,18 +17,18 @@ jobs:
   milestone_checker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-      if: github.repository == 'spacetelescope/slitlessutils'
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const { data } = await github.request("GET /repos/{owner}/{repo}/pulls/{pr}", {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pr: context.payload.pull_request.number
-            });
-            if (data.milestone) {
-              core.info(`This pull request has a milestone set: ${data.milestone.title}`);
-            } else {
-              core.setFailed(`A maintainer needs to set the milestone for this pull request.`);
-            }
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: github.repository == 'spacetelescope/slitlessutils'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data } = await github.request("GET /repos/{owner}/{repo}/pulls/{pr}", {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pr: context.payload.pull_request.number
+              });
+              if (data.milestone) {
+                core.info(`This pull request has a milestone set: ${data.milestone.title}`);
+              } else {
+                core.setFailed(`A maintainer needs to set the milestone for this pull request.`);
+              }

--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -2,7 +2,7 @@ name: Daily Cron Tests
 
 on:
   schedule:
-    # run at 6am UTC on Tue-Fri (complete tests are run every Monday)
+    # Run at 6am UTC on Tue-Fri (complete tests are run every Monday)
     - cron: '0 6 * * 2-5'
   pull_request:
     # We also want this workflow triggered if the 'Daily CI' label is added
@@ -27,7 +27,14 @@ permissions:
 
 jobs:
   tests:
-    if: (github.repository == 'spacetelescope/slitlessutils' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Daily CI')))
+    if: |
+      github.repository == 'spacetelescope/slitlessutils' &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'Daily CI')
+      )
     name: ${{ matrix.prefix }} ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow_failure }}

--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -48,29 +48,29 @@ jobs:
             prefix: '(Allowed failure)'
 
     steps:
-    - name: Check out repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        persist-credentials: false
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-      with:
-        persist-credentials: false
-        python-version: ${{ matrix.python }}
-    - name: Install base dependencies
-      run: python -m pip install --upgrade pip setuptools tox
-    - name: Print Python, pip, setuptools, and tox versions
-      run: |
-        python -c "import sys; print(f'Python {sys.version}')"
-        python -c "import pip; print(f'pip {pip.__version__}')"
-        python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
-        python -c "import tox; print(f'tox {tox.__version__}')"
-    - name: Run tests
-      run: tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}
-    - name: Upload coverage to codecov
-      if: ${{ contains(matrix.tox_env, '-cov') }}
-      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
-      with:
-        files: ./coverage.xml
-        verbose: true
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          persist-credentials: false
+          python-version: ${{ matrix.python }}
+      - name: Install base dependencies
+        run: python -m pip install --upgrade pip setuptools tox
+      - name: Print Python, pip, setuptools, and tox versions
+        run: |
+          python -c "import sys; print(f'Python {sys.version}')"
+          python -c "import pip; print(f'pip {pip.__version__}')"
+          python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
+          python -c "import tox; print(f'tox {tox.__version__}')"
+      - name: Run tests
+        run: tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}
+      - name: Upload coverage to codecov
+        if: ${{ contains(matrix.tox_env, '-cov') }}
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          files: ./coverage.xml
+          verbose: true

--- a/.github/workflows/ci_test_predeps.yml
+++ b/.github/workflows/ci_test_predeps.yml
@@ -1,0 +1,55 @@
+name: Test Pre-release Dependencies
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: ${{ matrix.os }}, ${{ matrix.tox_env }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: '3.14'
+            tox_env: 'py314-test-predeps'
+            toxposargs: --remote-data
+
+          - os: macos-latest
+            python: '3.14'
+            tox_env: 'py314-test-predeps'
+
+          - os: windows-latest
+            python: '3.14'
+            tox_env: 'py314-test-predeps'
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python }}
+          allow-prereleases: true
+      - name: Install base dependencies
+        run: python -m pip install --upgrade pip setuptools tox
+      - name: Print Python, pip, setuptools, and tox versions
+        run: |
+          python -c "import sys; print(f'Python {sys.version}')"
+          python -c "import pip; print(f'pip {pip.__version__}')"
+          python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
+          python -c "import tox; print(f'tox {tox.__version__}')"
+      - name: Run tests
+        run: python -m tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -89,29 +89,29 @@ jobs:
             prefix: '(Allowed failure)'
 
     steps:
-    - name: Check out repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        persist-credentials: false
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-      with:
-        persist-credentials: false
-        python-version: ${{ matrix.python }}
-    - name: Install base dependencies
-      run: python -m pip install --upgrade pip setuptools tox
-    - name: Print Python, pip, setuptools, and tox versions
-      run: |
-        python -c "import sys; print(f'Python {sys.version}')"
-        python -c "import pip; print(f'pip {pip.__version__}')"
-        python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
-        python -c "import tox; print(f'tox {tox.__version__}')"
-    - name: Run tests
-      run: tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}
-    - name: Upload coverage to codecov
-      if: ${{ contains(matrix.tox_env, '-cov') }}
-      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
-      with:
-        files: ./coverage.xml
-        verbose: true
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          persist-credentials: false
+          python-version: ${{ matrix.python }}
+      - name: Install base dependencies
+        run: python -m pip install --upgrade pip setuptools tox
+      - name: Print Python, pip, setuptools, and tox versions
+        run: |
+          python -c "import sys; print(f'Python {sys.version}')"
+          python -c "import pip; print(f'pip {pip.__version__}')"
+          python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
+          python -c "import tox; print(f'tox {tox.__version__}')"
+      - name: Run tests
+        run: tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}
+      - name: Upload coverage to codecov
+        if: ${{ contains(matrix.tox_env, '-cov') }}
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          files: ./coverage.xml
+          verbose: true

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -8,7 +8,7 @@ on:
       - '*'
   pull_request:
   schedule:
-    # run every Monday at 4am UTC
+    # Run every Monday at 4am UTC
     - cron: '0 4 * * 1'
   workflow_dispatch:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       contents: none
 
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef  # v2.6.3
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef # v2.6.3
 
     if: (github.repository == 'spacetelescope/slitlessutils' && (github.event_name == 'push' ||  github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Wheel building
 
 on:
   schedule:
-    # run every Monday at 5am UTC
+    # Run every Monday at 5am UTC
     - cron: '0 5 * * 1'
   pull_request:
     # We also want this workflow triggered if the 'Build all wheels'
@@ -20,27 +20,62 @@ on:
       - '!*post*'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   build_and_publish:
-    # This job builds the wheels and publishes them to PyPI for all
-    # tags, except those ending in ".dev". For PRs with the "Build all
-    # wheels" label, wheels are built, but are not uploaded to PyPI.
-
     permissions:
       contents: none
 
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef # v2.6.3
 
-    if: (github.repository == 'spacetelescope/slitlessutils' && (github.event_name == 'push' ||  github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
+    if: |
+      github.repository == 'spacetelescope/slitlessutils' &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'Build all wheels')
+      )
     with:
-      # We upload to PyPI for all tag pushes, except tags ending in .dev
-      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/') && !endsWith(github.ref, '.dev') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+      upload_to_pypi: false
+      save_artifacts: true
 
       test_extras: test
       test_command: pytest -p no:warnings --pyargs slitlessutils
 
-    secrets:
-      pypi_token: ${{ secrets.pypi_token }}
+  upload:
+    # This job publishes the built wheels to PyPI for all tags, except
+    # those ending in ".dev". For PRs with the "Build all wheels" label,
+    # wheels are built, but are not uploaded to PyPI.
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/slitlessutils/
+    # We upload to PyPI for all tag pushes, except tags ending in .dev
+    if: |
+      needs.build_and_publish.result == 'success' &&
+      startsWith(github.ref, 'refs/tags/') &&
+      !endsWith(github.ref, '.dev') &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch'
+      )
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: [build_and_publish]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+          pattern: dist-*
+          path: dist
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,10 +32,10 @@ repos:
         # Checks for the existence of private keys.
       - id: end-of-file-fixer
         # Makes sure files end in a newline and only a newline.
-        exclude: ".*(svg.*|extern.*)$"
+        exclude: '.*(svg.*|extern.*)$'
       - id: trailing-whitespace
         # Trims trailing whitespace.
-        exclude: ".*(data.*|extern.*)$"
+        exclude: '.*(data.*|extern.*)$'
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
@@ -56,7 +56,7 @@ repos:
     rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: ["--py311-plus"]
+        args: ['--py311-plus']
 
   - repo: https://github.com/pycqa/isort
     rev: 9.0.0a3
@@ -69,7 +69,7 @@ repos:
     rev: 7.3.0
     hooks:
       - id: flake8
-        args: ["--ignore", "E501,E741,W503,W504"]
+        args: ['--ignore', 'E501,E741,W503,W504']
 
   - repo: https://github.com/asottile/yesqa
     rev: v1.5.0
@@ -80,8 +80,14 @@ repos:
     rev: v2.4.2
     hooks:
       - id: codespell
-        args: ["--write-changes", "--ignore-words-list",
-               "Pidgeon, exten, som, ot", "--skip", "*.pdf"]
+        args:
+          [
+            '--write-changes',
+            '--ignore-words-list',
+            'Pidgeon, exten, som, ot',
+            '--skip',
+            '*.pdf',
+          ]
         additional_dependencies:
           - tomli
 
@@ -89,4 +95,16 @@ repos:
     rev: v2.3.2
     hooks:
       - id: autopep8
-        args: ["--in-place", "--aggressive"]
+        args: ['--in-place', '--aggressive']
+
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.3
+    hooks:
+      - id: prettier
+        types_or: [css, rst, json, yaml, toml, markdown]
+        args: ['--single-quote']
+        # Exclude codeql.yml, dependabot.yml, README.md
+        exclude: |
+          (?x)^(
+            (.*\/)?(codeql\.yml|dependabot\.yml|README.md)$
+          )

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.12"
+    python: '3.12'
   jobs:
     post_checkout:
       - git fetch --shallow-since=2023-09-01 || true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: '3.12'
+    python: '3.14'
   jobs:
     post_checkout:
       - git fetch --shallow-since=2023-09-01 || true

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{312,313,314}-test{,-devdeps}{,-cov}
+    py{312,313,314}-test{,-devdeps,-predeps}{,-cov}
     build_docs
     linkcheck
     codestyle
@@ -61,6 +61,10 @@ commands =
     pytest --pyargs slitlessutils {toxinidir}/docs \
     cov: --cov slitlessutils --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml \
     {posargs}
+
+pip_pre =
+    predeps: true
+    !predeps: false
 
 [testenv:build_docs]
 changedir = docs


### PR DESCRIPTION
This PR also:
* Adds `prettier` to the pre-commit hooks
* Adds a `pre-deps` tox env for testing pre-releases of dependencies

I've updated PyPI to use Trusted Publishing.